### PR TITLE
Multiple nvidia GPU support and ffmpeg error catching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
  "environment",
  "ffmpeg",
  "figlet-rs",
+ "gpus",
  "permutation",
  "text_io",
 ]
@@ -55,7 +56,7 @@ dependencies = [
  "clap_lex",
  "is-terminal",
  "once_cell",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
 ]
 
@@ -231,6 +232,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.9.3",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dont_disappear"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,6 +291,7 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 name = "engine"
 version = "0.1.0"
 dependencies = [
+ "cli",
  "compound_duration",
  "crossbeam-channel",
  "ctrlc",
@@ -319,6 +356,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "gpus"
+version = "0.1.0"
+dependencies = [
+ "nvml-wrapper",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +388,12 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indicatif"
@@ -395,6 +451,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +499,29 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "nvml-wrapper"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd21b9f5a1cce3c3515c9ffa85f5c7443e07162dae0ccf4339bb7ca38ad3454"
+dependencies = [
+ "bitflags",
+ "libloading",
+ "nvml-wrapper-sys",
+ "static_assertions",
+ "thiserror",
+ "wrapcenum-derive",
+]
+
+[[package]]
+name = "nvml-wrapper-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c961a2ea9e91c59a69b78e69090f6f5b867bb46c0c56de9482da232437c4987e"
+dependencies = [
+ "libloading",
+]
 
 [[package]]
 name = "once_cell"
@@ -576,6 +665,12 @@ checksum = "e6700c1ed393aa9c1fff950032a64a4856436dadee820641ce1b914cab65019f"
 
 [[package]]
 name = "strsim"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
+
+[[package]]
+name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -614,6 +709,26 @@ name = "text_io"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f0c8eb2ad70c12a6a69508f499b3051c924f4b1cfeae85bfad96e6bc5bba46"
+
+[[package]]
+name = "thiserror"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -744,3 +859,15 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "wrapcenum-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bcc065c85ad2c3bd12aa4118bf164835712e25080c392557801a13292c60aec"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,6 @@ members = [
     "ffmpeg",
     "permutation",
     "permutor-cli",
-    "cli"
+    "cli",
+    "gpus"
 ]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ resolutions and framerates).
 A nice cross-platform tool to test your SSD's sequential read speeds: <a href='https://www.jazzdiskbench.com/'>Jazz Disk
 Bench</a>
 
+Note: the tool _does_ support selecting a specific GPU in your system if you have more than one, but you may experience
+PCI bottlenecking for GPU's not in the primary slot.
+
 ### Important notes about your system
 
 - do make sure your SSD drive in Windows does _not_ have drive compression enabled. This can severely affect your
@@ -88,7 +91,8 @@ Assuming you have followed the [Installation Setup Requirements](#installation--
 benchmark is as simple as:
 
 1) Opening the **benchmark** executable as you would any other program (double-click)
-2) Follow the on-screen instructions: select your encoder, and whether to run it on all resolutions or just a specific
+2) Follow the on-screen instructions: select your GPU (if you have more than 1, otherwise it auto-selects your only
+   card), select your encoder, and whether to run it on all resolutions or just a specific
    one
 3) Wait for the benchmark to finish, which should not take that long
 
@@ -194,6 +198,17 @@ When the tool detects that you've hit a `95` vmaf score, it will stop permuting.
 stop permuting once it gets to `50Mb/s` because we know that's the point where you get visually lossless 4K@60 with
 H264_NVENC, and any higher amount of bitrate does not significantly improve quality and can actually reduce encoder
 performance.
+
+### Running on a specific GPU in a multi-GPU system
+
+By default, the **permutor-cli** tool will run against the first GPU in your system that it sees.
+
+Much like how the benchmark tool allows for you to select what GPU to run on, the **permutor-cli** tool does this as
+well.
+With this tool it's as simple as providing the `-gpu 0` option, where 0 in this case would run against your first GPU.
+
+Note: if you are not sure which GPU is considered in the first slot, open the **benchmark** and it'll list the order of
+your cards for you.
 
 ## Applying your Findings
 

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -13,3 +13,4 @@ permutation = { path = "../permutation" }
 engine = { path = "../engine" }
 ffmpeg = { path = "../ffmpeg" }
 cli = { path = "../cli" }
+gpus = { path = "../gpus" }

--- a/benchmark/src/benchmark_cli.rs
+++ b/benchmark/src/benchmark_cli.rs
@@ -17,6 +17,9 @@ pub struct BenchmarkCli {
     /// logs useful information to help troubleshooting
     #[arg(short, long)]
     pub verbose: bool,
+    /// the GPU you wish to run the encode on; defaults to the first/only GPU found in your system
+    #[arg(short, long, default_value = "0")]
+    pub gpu: u8,
     was_ui_opened: bool,
 }
 
@@ -32,6 +35,7 @@ impl BenchmarkCli {
             encoder: String::from(""),
             source_file: String::from(""),
             verbose: false,
+            gpu: 0,
             was_ui_opened: false,
         };
     }

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -14,3 +14,4 @@ indicatif = "0.17.2"
 stoppable_thread = "0.2.1"
 permutation = { path = "../permutation" }
 ffmpeg = { path = "../ffmpeg" }
+cli = { path = "../cli" }

--- a/gpus/Cargo.toml
+++ b/gpus/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "gpus"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+nvml-wrapper = "0.9.0"

--- a/gpus/src/device.rs
+++ b/gpus/src/device.rs
@@ -1,0 +1,16 @@
+use nvml_wrapper::enum_wrappers::device::Brand;
+
+// our own wrapper for device information to get around lifetime issues
+pub struct Device {
+    pub brand: Brand,
+    pub name: String,
+}
+
+impl Device {
+    pub fn new() -> Self {
+        return Self {
+            brand: Brand::Unknown,
+            name: String::from("")
+        };
+    }
+}

--- a/gpus/src/lib.rs
+++ b/gpus/src/lib.rs
@@ -1,0 +1,17 @@
+use nvml_wrapper::Nvml;
+
+pub mod device;
+
+pub fn get_gpus() -> Vec<String> {
+    let nvml = Nvml::init().unwrap();
+    let device_count = nvml.device_count().unwrap();
+
+    let mut list = Vec::new();
+
+    for i in 0..device_count {
+        let nvml_device = nvml.device_by_index(i).unwrap();
+        list.push(nvml_device.name().unwrap());
+    }
+
+    return list;
+}

--- a/permutor-cli/src/main.rs
+++ b/permutor-cli/src/main.rs
@@ -16,7 +16,7 @@ fn main() {
     log_special_arguments(&cli);
 
     let mut engine = PermutationEngine::new();
-    let mut nvenc = Nvenc::new(cli.encoder == "hevc_nvenc");
+    let mut nvenc = Nvenc::new(cli.encoder == "hevc_nvenc", cli.gpu);
     for bitrate in get_bitrate_permutations(cli.bitrate, cli.max_bitrate_permutation.unwrap()) {
         build_setting_permutations(&mut engine, &mut nvenc, &cli, bitrate);
     }

--- a/permutor-cli/src/permutor_cli.rs
+++ b/permutor-cli/src/permutor_cli.rs
@@ -31,6 +31,9 @@ pub struct PermutorCli {
     /// lists the supported/implemented supported that this tool supports
     #[arg(short, long)]
     pub list_supported_encoders: bool,
+    /// the GPU you wish to run the encode on; defaults to the first/only GPU found in your system
+    #[arg(short, long, default_value = "0")]
+    pub gpu: u8,
 }
 
 impl PermutorCli {


### PR DESCRIPTION
- reads whether you have more than 1 GPU in your system, and allows you to select which one
(applies to both the benchmark and the permutor-cli tool)
- checks if no progress has been made on the GPU encode in 10 seconds, indicating most likely an ffmpeg error happened