### PR TITLE
Replace from_creation_date in favor of a cross platform solution

### DIFF
--- a/.github/workflows/pull_request_workflow.yml
+++ b/.github/workflows/pull_request_workflow.yml
@@ -34,4 +34,4 @@ jobs:
           key: ${{inputs.platform}}-${{github.sha}}
 
       - name: Run Unit Tests
-        run: cargo test --no-fail-fast -- --show-output
+        run: cargo test --no-fail-fast

--- a/.github/workflows/pull_request_workflow.yml
+++ b/.github/workflows/pull_request_workflow.yml
@@ -34,4 +34,4 @@ jobs:
           key: ${{inputs.platform}}-${{github.sha}}
 
       - name: Run Unit Tests
-        run: cargo test --no-fail-fast
+        run: cargo test --no-fail-fast -- --show-output

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ target/
 
 # ignore the on-the-fly font file embedded in the executable
 tmp.flf
+
+# ignore tmp files created from unit tests
+ffmpeg/*log*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "benchmark",
@@ -11,3 +12,4 @@ members = [
     "gpus",
     "codecs"
 ]
+

--- a/ffmpeg/src/report_files.rs
+++ b/ffmpeg/src/report_files.rs
@@ -21,9 +21,9 @@ pub fn get_latest_ffmpeg_report_file() -> PathBuf {
 
     while index != log_entries.len() {
         entry = log_entries.get(index);
-        let file_time = FileTime::from_creation_time(&entry.unwrap().metadata().unwrap()).unwrap();
+        let file_time = FileTime::from_last_modification_time(&entry.unwrap().metadata().unwrap());
         if file_time > latest_time {
-            latest_time = FileTime::from_creation_time(&entry.unwrap().metadata().unwrap()).unwrap();
+            latest_time = FileTime::from_last_modification_time(&entry.unwrap().metadata().unwrap());
             log_file = entry;
         }
 

--- a/ffmpeg/src/report_files.rs
+++ b/ffmpeg/src/report_files.rs
@@ -141,7 +141,7 @@ mod tests {
 
         fs::create_dir(test_latest_log_dir_path_str).expect(EXPECTED_DIR_CREATED_MSG);
         let old_log_path_str = test_latest_log_dir_path_str.to_string() + "/ffmpeg-1.log";
-        let old_log_file = fs::File::create(old_log_path_str).expect(EXPECTED_TMP_CREATED_MSG);
+        let old_log_file = fs::File::create(old_log_path_str).expect(EXPECTED_TMP_FILE_CREATED_MSG);
         old_log_file.sync_all().unwrap();
 
         let new_log_path_str = test_latest_log_dir_path_str.to_string() + "/ffmpeg-2.log";

--- a/ffmpeg/src/report_files.rs
+++ b/ffmpeg/src/report_files.rs
@@ -10,36 +10,8 @@ use regex::Regex;
 use rev_buf_reader::RevBufReader;
 
 pub fn get_latest_ffmpeg_report_file() -> PathBuf {
-    let mut log_file = None;
-    let mut latest_time = FileTime::zero();
     let log_entries = get_logs_in_directory(".");
-
-    // defining entry here so we can extend it's scope
-    let mut entry: Option<&DirEntry>;
-    let mut index = 0;
-    let mut file_time;
-
-    while index != log_entries.len() {
-        entry = log_entries.get(index);
-        let metadata = &entry.unwrap().metadata().unwrap();
-        println!("{:?}", &entry.unwrap());
-        if metadata.created().is_ok() {
-            println!("Using created file field");
-            file_time = FileTime::from_system_time(metadata.created().unwrap());
-        } else {
-            // Platforms that support metadata.created() will use
-            // last modification time as a fallback
-            file_time = FileTime::from_last_modification_time(metadata);
-        }
-
-        if file_time > latest_time {
-            latest_time = file_time;
-            log_file = entry;
-        }
-
-        index = index + 1;
-    }
-
+    let log_file = get_latest_log(log_entries);
     return log_file.unwrap().path();
 }
 
@@ -71,6 +43,7 @@ pub fn capture_group(str: &str, regex: &str) -> String {
 }
 
 fn get_logs_in_directory(dir: &str) -> Vec<DirEntry> {
+    // Only match ffmpeg log files
     let re = Regex::new(r"^ffmpeg.*?\.log$").unwrap();
     let paths = fs::read_dir(dir).unwrap();
     return paths
@@ -79,6 +52,31 @@ fn get_logs_in_directory(dir: &str) -> Vec<DirEntry> {
             p.file_type().unwrap().is_file() && re.is_match(p.file_name().to_str().unwrap())
         })
         .collect::<Vec<DirEntry>>();
+}
+
+fn get_latest_log(log_entries: Vec<DirEntry>) -> Option<DirEntry> {
+    let mut log_file: Option<DirEntry> = None;
+    let mut latest_time = FileTime::zero();
+
+    // defining file_time here so we can extend it's scope
+    let mut file_time;
+
+    for entry in log_entries.into_iter() {
+        let metadata = entry.metadata().unwrap();
+        if metadata.created().is_ok() {
+            file_time = FileTime::from_system_time(metadata.created().unwrap());
+        } else {
+            // Platforms that don't support metadata.created() will use the
+            // last modification time as a fallback
+            file_time = FileTime::from_last_modification_time(&metadata);
+        }
+
+        if file_time > latest_time {
+            latest_time = file_time;
+            log_file = Some(entry);
+        }
+    }
+    return log_file;
 }
 
 #[cfg(test)]

--- a/ffmpeg/src/report_files.rs
+++ b/ffmpeg/src/report_files.rs
@@ -132,14 +132,19 @@ mod tests {
             .expect("Unable to create temporary log file for testing");
         file2.sync_all().unwrap();
         let log_files = get_logs_in_directory("./latest-log-test");
-        let latest_log_file = get_latest_log(log_files);
+        // let latest_log_file = get_latest_log(log_files);
+        //debug
+        for file in log_files {
+            println!("{:?}", file.file_name());
+            println!("{:?}", &file.metadata().unwrap());
+        }
         // assert latest log file name
-        assert!(latest_log_file
-            .unwrap()
-            .file_name()
-            .to_str()
-            .unwrap()
-            .contains("ffmpeg-2.log"));
+        // assert!(latest_log_file
+        //     .unwrap()
+        //     .file_name()
+        //     .to_str()
+        //     .unwrap()
+        //     .contains("ffmpeg-2.log"));
         fs::remove_dir_all("./latest-log-test").unwrap();
     }
 }

--- a/ffmpeg/src/report_files.rs
+++ b/ffmpeg/src/report_files.rs
@@ -139,9 +139,9 @@ mod tests {
             fs::remove_dir_all(test_latest_log_dir_path_str).unwrap();
         }
 
-        fs::create_dir(test_latest_log_dir_path_str).unwrap();
+        fs::create_dir(test_latest_log_dir_path_str).expect(EXPECTED_DIR_CREATED_MSG);
         let old_log_path_str = test_latest_log_dir_path_str.to_string() + "/ffmpeg-1.log";
-        let old_log_file = fs::File::create(old_log_path_str).expect(EXPECTED_DIR_CREATED_MSG);
+        let old_log_file = fs::File::create(old_log_path_str).expect(EXPECTED_TMP_CREATED_MSG);
         old_log_file.sync_all().unwrap();
 
         let new_log_path_str = test_latest_log_dir_path_str.to_string() + "/ffmpeg-2.log";

--- a/ffmpeg/src/report_files.rs
+++ b/ffmpeg/src/report_files.rs
@@ -44,7 +44,7 @@ pub fn get_latest_ffmpeg_report_file() -> PathBuf {
 }
 
 pub fn extract_vmaf_score(line: &str) -> Result<c_float, ParseFloatError> {
-    return capture_group(line, r"VMAF score: ([0-9]+\.[0-9]+)").parse::<c_float>();
+    return capture_group(line, r"VMAF score: (\d+\.\d+)").parse::<c_float>();
 }
 
 pub fn read_last_line_at(line_number: i32) -> String {

--- a/ffmpeg/src/report_files.rs
+++ b/ffmpeg/src/report_files.rs
@@ -144,19 +144,13 @@ mod tests {
         let old_log_file = fs::File::create(old_log_path_str).expect(EXPECTED_TMP_FILE_CREATED_MSG);
         old_log_file.sync_all().unwrap();
 
+        // Added sleep to ensure the 2nd file gets created at a later timestamp
         std::thread::sleep(std::time::Duration::from_millis(3000));
-
 
         let new_log_path_str = test_latest_log_dir_path_str.to_string() + "/ffmpeg-2.log";
         let new_log_file = fs::File::create(new_log_path_str).expect(EXPECTED_TMP_FILE_CREATED_MSG);
         new_log_file.sync_all().unwrap();
         let log_files = get_logs_in_directory(test_latest_log_dir_path_str);
-        //debug
-        for file in &log_files {
-            println!("{:?}", file.file_name());
-            println!("{:?}", &file.metadata().unwrap());
-        }
-
         let latest_log_file = get_latest_log(log_files);
         // assert latest log file name
         assert!(latest_log_file

--- a/ffmpeg/src/report_files.rs
+++ b/ffmpeg/src/report_files.rs
@@ -144,6 +144,9 @@ mod tests {
         let old_log_file = fs::File::create(old_log_path_str).expect(EXPECTED_TMP_FILE_CREATED_MSG);
         old_log_file.sync_all().unwrap();
 
+        std::thread::sleep(std::time::Duration::from_millis(3000));
+
+
         let new_log_path_str = test_latest_log_dir_path_str.to_string() + "/ffmpeg-2.log";
         let new_log_file = fs::File::create(new_log_path_str).expect(EXPECTED_TMP_FILE_CREATED_MSG);
         new_log_file.sync_all().unwrap();


### PR DESCRIPTION
## Summary of Changes
Addresses https://github.com/Proryanator/encoder-benchmark/issues/22

### Resolver set to 2
See:
- https://substrate.stackexchange.com/questions/9011/warning-some-crates-are-on-edition-2021-which-defaults-to-resolver-2
- https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2

### Replace `FileTime::from_creation_date`
See https://github.com/Proryanator/encoder-benchmark/issues/22 for more details.

https://docs.rs/filetime/latest/filetime/struct.FileTime.html#method.from_last_access_time
Access time should be avoided. If there was an older ffmpeg log and I ran `cat` that would update the access time to the current time. That would cause the script to potentially grab an older log. (This would only happen when ffmpeg is done writing the log, and someone accessed an older log)

### Future Notes
@Proryanator  Perhaps some notes for the future
A potential robust solution is to not depend on file metadata to calculate the latest log. Maybe the script could look at the filename of the ffmpeg log.
On my linux system it looks like this: `ffmpeg-20230916-080718.log`. It may be enough to perform a sort descending on the filename and grab the first from the DirEntry vector. Otherwise you can parse the timestamp to create the FileTime and reuse your current implementation to calculate the latest log.

Some race conditions would exist if running the `permutor-cli` tool multiple times within the same dir. The script would need some sort of unique hash / execution id to ensure it grabs the correct latest log. I suppose you could append that to the ffmpeg log filename.