### PR TITLE
Add retry logic to check encode quality

### DIFF
--- a/engine/src/permutation_engine.rs
+++ b/engine/src/permutation_engine.rs
@@ -57,7 +57,10 @@ impl PermutationEngine {
             log_permutation_header(i, &self.permutations, calc_time, ignore_factor);
 
             // if this permutation was added to the list of duplicates, skip to save calculation time
-            if !permutation.allow_duplicates && permutation.check_quality && will_be_duplicate(&self.dup_results, &permutation) {
+            if !permutation.allow_duplicates
+                && permutation.check_quality
+                && will_be_duplicate(&self.dup_results, &permutation)
+            {
                 draw_yellow_bar(permutation.get_metadata().frames);
                 println!("\n!!! Above encoder settings will produce identical vmaf score as other permutations, skipping... \n");
                 continue;
@@ -71,7 +74,11 @@ impl PermutationEngine {
                 let mut quality_val = None;
                 for attempt in 0..MAX_ATTEMPTS_CALC_QUALITY {
                     print!("  [ATTEMPT {}/{}] ", attempt + 1, MAX_ATTEMPTS_CALC_QUALITY);
-                    quality_val = check_encode_quality(permutation.clone(), &ctrl_channel, permutation.verbose);
+                    quality_val = check_encode_quality(
+                        permutation.clone(),
+                        &ctrl_channel,
+                        permutation.verbose,
+                    );
                     match quality_val {
                         Some(val) => {
                             result.vmaf_score = val;
@@ -83,7 +90,10 @@ impl PermutationEngine {
                 }
 
                 if quality_val.is_none() {
-                    panic!("Error, Failed to calc encode quality after {} attempts", MAX_ATTEMPTS_CALC_QUALITY);
+                    panic!(
+                        "Error, Failed to calc encode quality after {} attempts",
+                        MAX_ATTEMPTS_CALC_QUALITY
+                    );
                 }
 
                 result.vmaf_calculation_time = vmaf_start_time.elapsed().unwrap().as_secs();
@@ -97,8 +107,14 @@ impl PermutationEngine {
                 calc_time = Option::from(permutation_start_time.elapsed().unwrap());
             }
 
-            let is_initial_bitrate_permutation_over = i == self.permutations.len() - 1 || self.permutations[i + 1].clone().bitrate != permutation.bitrate;
-            self.add_result(result, is_initial_bitrate_permutation_over, permutation.check_quality, permutation.allow_duplicates);
+            let is_initial_bitrate_permutation_over = i == self.permutations.len() - 1
+                || self.permutations[i + 1].clone().bitrate != permutation.bitrate;
+            self.add_result(
+                result,
+                is_initial_bitrate_permutation_over,
+                permutation.check_quality,
+                permutation.allow_duplicates,
+            );
 
             // we'll calculate the ignore factor of permutations that will be skipped
             if is_initial_bitrate_permutation_over {
@@ -109,14 +125,23 @@ impl PermutationEngine {
 
             // stop if we've found the target quality, and we're done permuting over the current bitrate
             if target_quality_found && is_initial_bitrate_permutation_over {
-                println!("Found VMAF score >= {}, stopping permutations...", TARGET_QUALITY);
+                println!(
+                    "Found VMAF score >= {}, stopping permutations...",
+                    TARGET_QUALITY
+                );
                 break;
             }
         }
 
         // produce output files and other logging here
         let runtime_str = format_dhms(runtime.elapsed().unwrap().as_secs());
-        log_results_to_file(self.results.clone(), &runtime_str, self.dup_results.clone(), self.permutations[0].bitrate, false);
+        log_results_to_file(
+            self.results.clone(),
+            &runtime_str,
+            self.dup_results.clone(),
+            self.permutations[0].bitrate,
+            false,
+        );
         println!("Benchmark runtime: {}", runtime_str);
     }
 
@@ -124,10 +149,20 @@ impl PermutationEngine {
         self.permutations.push(permutation);
     }
 
-    fn add_result(&mut self, result: PermutationResult, is_bitrate_permutation_over: bool, is_checking_quality: bool, allow_duplicates: bool) {
+    fn add_result(
+        &mut self,
+        result: PermutationResult,
+        is_bitrate_permutation_over: bool,
+        is_checking_quality: bool,
+        allow_duplicates: bool,
+    ) {
         // only do this duplicate mapping during the first bitrate permutation
         // notice how we do not add this for overloaded results
-        if !allow_duplicates && is_checking_quality && !result.was_overloaded && !is_bitrate_permutation_over {
+        if !allow_duplicates
+            && is_checking_quality
+            && !result.was_overloaded
+            && !is_bitrate_permutation_over
+        {
             let score_str = result.vmaf_score.to_string();
             if !self.vmaf_scores.contains(&score_str) {
                 self.results.push(result);
@@ -142,16 +177,31 @@ impl PermutationEngine {
     }
 }
 
-fn check_encode_quality(mut p: Permutation, ctrl_channel: &Result<Receiver<()>, Error>, verbose: bool) -> Option<c_float> {
-    let ffmpeg_args = FfmpegArgs::build_ffmpeg_args(p.video_file.clone(), p.encoder.clone(), &p.encoder_settings, p.bitrate.clone(), p.decode_run);
+fn check_encode_quality(
+    mut p: Permutation,
+    ctrl_channel: &Result<Receiver<()>, Error>,
+    verbose: bool,
+) -> Option<c_float> {
+    let ffmpeg_args = FfmpegArgs::build_ffmpeg_args(
+        p.video_file.clone(),
+        p.encoder.clone(),
+        &p.encoder_settings,
+        p.bitrate.clone(),
+        p.decode_run,
+    );
 
-    println!("Calculating vmaf score; might take longer than original encode depending on your CPU...");
+    println!(
+        "Calculating vmaf score; might take longer than original encode depending on your CPU..."
+    );
 
     let metadata = p.get_metadata();
     // first spawn the ffmpeg instance to listen for incoming encode
     let vmaf_args = ffmpeg_args.map_to_vmaf(metadata.fps);
     if p.verbose {
-        println!("V: Vmaf args calculating quality: {}", vmaf_args.to_string());
+        println!(
+            "V: Vmaf args calculating quality: {}",
+            vmaf_args.to_string()
+        );
     }
 
     let mut vmaf_child = spawn_ffmpeg_child(&vmaf_args, verbose, None);
@@ -162,24 +212,39 @@ fn check_encode_quality(mut p: Permutation, ctrl_channel: &Result<Receiver<()>, 
     encoder_args.output_args = String::from(insert_format_from(TCP_OUTPUT, &ffmpeg_args.encoder));
 
     if p.verbose {
-        println!("V: Encoder fmmpeg args sending to vmaf: {}", encoder_args.to_string());
+        println!(
+            "V: Encoder fmmpeg args sending to vmaf: {}",
+            encoder_args.to_string()
+        );
     }
 
     let mut encoder_child = spawn_ffmpeg_child(&encoder_args, verbose, None);
 
     // not the cleanest way to do this but oh well
-    progressbar::watch_encode_progress(metadata.frames, false, metadata.fps, false, ffmpeg_args.stats_period, ctrl_channel);
+    progressbar::watch_encode_progress(
+        metadata.frames,
+        false,
+        metadata.fps,
+        false,
+        ffmpeg_args.stats_period,
+        ctrl_channel,
+    );
 
     // need to wait for the vmaf calculating thread to finish
     println!("VMAF calculation finishing up...");
     let vmaf_child_status = vmaf_child.wait().expect("Vmaf child could not wait");
     let vmaf_score_line = read_last_line_at(3);
-    //Cleanup process 
-    encoder_child.kill().expect("Could not kill encoder process");
+    //Cleanup process
+    encoder_child
+        .kill()
+        .expect("Could not kill encoder process");
 
     if vmaf_child_status.success() {
         let vmaf_score_extract = extract_vmaf_score(vmaf_score_line.as_str());
-        let vmaf_score = vmaf_score_extract.expect(&format!("Could not parse score from line: {}", vmaf_score_line));
+        let vmaf_score = vmaf_score_extract.expect(&format!(
+            "Could not parse score from line: {}",
+            vmaf_score_line
+        ));
         println!("VMAF score: {}\n", vmaf_score);
         // Cleanup log file
         let vmaf_log_file = get_latest_ffmpeg_report_file();
@@ -187,7 +252,7 @@ fn check_encode_quality(mut p: Permutation, ctrl_channel: &Result<Receiver<()>, 
         return Some(vmaf_score);
     }
 
-    return None
+    return None;
 }
 
 fn will_be_duplicate(duplicates: &Vec<PermutationResult>, next_permutation: &Permutation) -> bool {
@@ -201,7 +266,13 @@ fn will_be_duplicate(duplicates: &Vec<PermutationResult>, next_permutation: &Per
 }
 
 fn insert_format_from(input: &str, encoder: &String) -> String {
-    let format = if encoder.contains("h264") { "h264" } else if encoder.contains("hevc") { "hevc" } else {"ivf"};
+    let format = if encoder.contains("h264") {
+        "h264"
+    } else if encoder.contains("hevc") {
+        "hevc"
+    } else {
+        "ivf"
+    };
     // this should be cleaner when we support more than 1 type
     return input.replace("{}", format);
 }

--- a/ffmpeg/src/args.rs
+++ b/ffmpeg/src/args.rs
@@ -44,7 +44,13 @@ impl Default for FfmpegArgs {
 }
 
 impl FfmpegArgs {
-    pub fn build_ffmpeg_args(first_input: String, encoder: String, encoder_args: &String, current_bitrate: u32, decode: bool) -> FfmpegArgs {
+    pub fn build_ffmpeg_args(
+        first_input: String,
+        encoder: String,
+        encoder_args: &String,
+        current_bitrate: u32,
+        decode: bool,
+    ) -> FfmpegArgs {
         let ffmpeg_args = FfmpegArgs {
             first_input,
             bitrate: current_bitrate,
@@ -78,7 +84,13 @@ impl FfmpegArgs {
 
         // not all will want to send progress
         if self.send_progress {
-            output.push_str(format!("-progress tcp://localhost:1234 -stats_period {} ", self.stats_period).as_str());
+            output.push_str(
+                format!(
+                    "-progress tcp://localhost:1234 -stats_period {} ",
+                    self.stats_period
+                )
+                .as_str(),
+            );
         }
 
         // always pass the '-y' flag, for output to be overwritten
@@ -90,7 +102,7 @@ impl FfmpegArgs {
                 Vendor::Nvidia => "cuda",
                 Vendor::AMD => "d3d11va",
                 Vendor::IntelQSV => "qsv",
-                Vendor::Unknown => "error"
+                Vendor::Unknown => "error",
             };
 
             output.push_str("-hwaccel ");
@@ -121,7 +133,12 @@ impl FfmpegArgs {
             if self.is_vmaf {
                 append_vmaf_only_args(&mut output);
             } else {
-                append_encode_only_args(&mut output, self.bitrate, &self.encoder, &self.encoder_args);
+                append_encode_only_args(
+                    &mut output,
+                    self.bitrate,
+                    &self.encoder,
+                    &self.encoder_args,
+                );
             }
         }
 
@@ -161,7 +178,12 @@ impl FfmpegArgs {
     }
 }
 
-fn append_encode_only_args(arg_str: &mut String, bitrate: u32, encoder: &String, encoder_args: &String) {
+fn append_encode_only_args(
+    arg_str: &mut String,
+    bitrate: u32,
+    encoder: &String,
+    encoder_args: &String,
+) {
     arg_str.push_str([" -b:v", bitrate.to_string().as_str()].join(" ").as_str());
     // adding the rate amount to the end of the bitrate
     arg_str.push('M');
@@ -171,7 +193,13 @@ fn append_encode_only_args(arg_str: &mut String, bitrate: u32, encoder: &String,
 }
 
 fn append_vmaf_only_args(arg_str: &mut String) {
-    arg_str.push_str(format!(" -filter_complex libvmaf='n_threads={}:n_subsample=5'", num_cpus::get()).as_str());
+    arg_str.push_str(
+        format!(
+            " -filter_complex libvmaf='n_threads={}:n_subsample=5'",
+            num_cpus::get()
+        )
+        .as_str(),
+    );
 }
 
 // TODO: get rid of this later
@@ -197,7 +225,8 @@ mod tests {
     static BITRATE: u32 = 6;
     static FPS_LIMIT: u32 = 60;
     static ENCODER: &str = "h264_nvenc";
-    static ENCODER_ARGS: &str = "-preset hq -tune hq -profile:v high -rc cbr -multipass qres -rc-lookahead 8";
+    static ENCODER_ARGS: &str =
+        "-preset hq -tune hq -profile:v high -rc cbr -multipass qres -rc-lookahead 8";
 
     #[test]
     fn default_args_test() {
@@ -291,7 +320,13 @@ mod tests {
             list_supported_encoders: false,
         };
 
-        return FfmpegArgs::build_ffmpeg_args(args.source_file, args.encoder, &ENCODER_ARGS.to_string(), args.bitrate, false);
+        return FfmpegArgs::build_ffmpeg_args(
+            args.source_file,
+            args.encoder,
+            &ENCODER_ARGS.to_string(),
+            args.bitrate,
+            false,
+        );
     }
 
     fn get_two_input_args() -> FfmpegArgs {

--- a/ffmpeg/src/args.rs
+++ b/ffmpeg/src/args.rs
@@ -273,7 +273,7 @@ mod tests {
     fn map_to_vmaf_to_string_test() {
         let vmaf_args = get_two_input_args().map_to_vmaf(FPS_LIMIT);
         assert_eq!(vmaf_args.to_string(),
-                   format!("-y -report -r {} -i tcp://localhost:2000?listen -r {} -i 1080-60.y4m -filter_complex libvmaf='n_threads={}:n_subsample=5' -f null -", FPS_LIMIT, FPS_LIMIT, num_cpus::get().to_string())
+                   format!("-y -report -r {} -i tcp://localhost:2000?listen&listen_timeout=3000&timeout=1000000 -r {} -i 1080-60.y4m -filter_complex libvmaf='n_threads={}:n_subsample=5' -f null -", FPS_LIMIT, FPS_LIMIT, num_cpus::get().to_string())
         );
     }
 

--- a/ffmpeg/src/args.rs
+++ b/ffmpeg/src/args.rs
@@ -302,7 +302,7 @@ mod tests {
     fn map_to_vmaf_to_string_test() {
         let vmaf_args = get_two_input_args().map_to_vmaf(FPS_LIMIT);
         assert_eq!(vmaf_args.to_string(),
-                   format!("-y -report -r {} -i tcp://localhost:2000?listen&listen_timeout=3000&timeout=1000000 -r {} -i 1080-60.y4m -filter_complex libvmaf='n_threads={}:n_subsample=5' -f null -", FPS_LIMIT, FPS_LIMIT, num_cpus::get().to_string())
+                   format!("-y -report -r {} -i {} -r {} -i 1080-60.y4m -filter_complex libvmaf='n_threads={}:n_subsample=5' -f null -", FPS_LIMIT, TCP_LISTEN, FPS_LIMIT, num_cpus::get().to_string())
         );
     }
 

--- a/ffmpeg/src/args.rs
+++ b/ffmpeg/src/args.rs
@@ -3,7 +3,7 @@ use std::ffi::c_float;
 use codecs::get_vendor_for_codec;
 use codecs::vendor::Vendor;
 
-pub static TCP_LISTEN: &str = "tcp://localhost:2000?listen";
+pub static TCP_LISTEN: &str = "tcp://localhost:2000?listen&listen_timeout=3000&timeout=1000000";
 pub static NO_OUTPUT: &str = "-f null -";
 
 #[derive(Clone)]

--- a/ffmpeg/src/report_files.rs
+++ b/ffmpeg/src/report_files.rs
@@ -44,7 +44,7 @@ pub fn capture_group(str: &str, regex: &str) -> String {
 
 fn get_logs_in_directory(dir: &str) -> Vec<DirEntry> {
     // Only match ffmpeg log files
-    let re = Regex::new(r"^ffmpeg.*?\.log$").unwrap();
+    let re = Regex::new(r"ffmpeg.*?\.log$").unwrap();
     let paths = fs::read_dir(dir).unwrap();
     return paths
         .filter_map(|e| e.ok())


### PR DESCRIPTION
Addresses #31 

## Summary of Changes
* Added timeout and listen_timeout to listen url [FFmpeg Protocols Documentation#tcp](https://ffmpeg.org/ffmpeg-protocols.html#tcp)
* Added retry logic when vmaf child process times out
* Ran `rustfmt` to format edited files  
   
![2023-09-26-215459_1920x436_scrot](https://github.com/Proryanator/encoder-benchmark/assets/16567905/e93cebcc-22b3-462a-a3a0-a643dabbdc24)


