### PR TITLE
Adding options to change source file input directory, and log output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ streaming at a target resolution & framerate.
 ### Identifying the minimum bitrate needed to achieve visually lossless video quality
 
 If you are unsure on the definition of visually lossless quality,
-see [Visually Lossless Terminology](#visually-lossless-terminology).
+see the wiki's terminology section.
 
 To find the minimum bitrate & encoder settings needed to achieve visually lossless quality, you would run something like
 the following:

--- a/benchmark/src/benchmark_cli.rs
+++ b/benchmark/src/benchmark_cli.rs
@@ -19,7 +19,7 @@ pub struct BenchmarkCli {
     /// the directory you wish the benchmark to look for your encoder files; can be used with --source_file/-s if you wish. Does NOT support spaces in directories
     #[arg(short, long, value_name = "folder/to/files", default_value = "")]
     pub files_directory: String,
-    /// the directory you wish for the logs this tool produces to go into; defaults to the current directory. Note: does not change the location of temporary log files (like the ones ffmpeg makes)
+    /// the directory you wish for the logs this tool produces to go into; defaults to the current directory. Does NOT support spaces in directories
     #[arg(long, value_name = "folder/to/log/output", default_value = "")]
     pub log_output_directory: String,
     /// logs useful information to help troubleshooting

--- a/benchmark/src/benchmark_cli.rs
+++ b/benchmark/src/benchmark_cli.rs
@@ -19,6 +19,9 @@ pub struct BenchmarkCli {
     /// the directory you wish the benchmark to look for your encoder files; can be used with --source_file/-s if you wish. Does NOT support spaces in directories
     #[arg(short, long, value_name = "folder/to/files", default_value = "")]
     pub files_directory: String,
+    /// the directory you wish for the logs this tool produces to go into; defaults to the current directory. Note: does not change the location of temporary log files (like the ones ffmpeg makes)
+    #[arg(long, value_name = "folder/to/log/output", default_value = "")]
+    pub log_output_directory: String,
     /// logs useful information to help troubleshooting
     #[arg(short, long)]
     pub verbose: bool,
@@ -45,6 +48,7 @@ impl BenchmarkCli {
             encoder: String::from(""),
             source_file: String::from(""),
             files_directory: String::from(""),
+            log_output_directory: String::from(""),
             verbose: false,
             gpu: 0,
             decode: false,

--- a/benchmark/src/benchmark_cli.rs
+++ b/benchmark/src/benchmark_cli.rs
@@ -16,6 +16,9 @@ pub struct BenchmarkCli {
     /// the source file you wish to benchmark; if not provided, will run standard benchmark on all supported resolutions
     #[arg(short, long, value_name = "source.y4m", default_value = "")]
     pub source_file: String,
+    /// the directory you wish the benchmark to look for your encoder files; can be used with --source_file/-s if you wish. Does NOT support spaces in directories
+    #[arg(short, long, value_name = "folder/to/files", default_value = "")]
+    pub files_directory: String,
     /// logs useful information to help troubleshooting
     #[arg(short, long)]
     pub verbose: bool,
@@ -25,6 +28,8 @@ pub struct BenchmarkCli {
     /// whether to run decode benchmark as well; defaults to off, as this will take up more storage space
     #[arg(short, long)]
     pub decode: bool,
+    // this is an internal option not intended to be exposed to the end user
+    #[arg(short, long, hide = true)]
     was_ui_opened: bool,
 }
 
@@ -39,6 +44,7 @@ impl BenchmarkCli {
             list_supported_encoders: false,
             encoder: String::from(""),
             source_file: String::from(""),
+            files_directory: String::from(""),
             verbose: false,
             gpu: 0,
             decode: false,
@@ -51,11 +57,12 @@ impl BenchmarkCli {
             self.list_supported_encoders,
             &self.encoder,
             &self.source_file,
+            &self.files_directory,
             self.was_ui_opened,
         );
 
         // if you did not provide a source file, we'll be running on all expected files
-        if self.source_file.is_empty() && !are_all_source_files_present() {
+        if self.source_file.is_empty() && !are_all_source_files_present(&self.files_directory) {
             println!("You're missing some video source files to run the standard benchmark; you should have the following: \n{:?}", get_supported_inputs());
             println!(
                 "Please download the ones you are missing from the project's readme section: {}",
@@ -63,6 +70,11 @@ impl BenchmarkCli {
             );
             println!("If you want to run the tool against a specific resolution/fps, download just that source file and specify it with '-s'");
             error_with_ack(self.was_ui_opened);
+        }
+
+        if self.files_directory.is_empty() && !self.files_directory.is_empty() {
+            // internally map the source_file and source_files_directory together
+            self.source_file = format!("{}/{}", self.files_directory, self.source_file);
         }
     }
 }

--- a/benchmark/src/benchmark_cli.rs
+++ b/benchmark/src/benchmark_cli.rs
@@ -72,7 +72,7 @@ impl BenchmarkCli {
             error_with_ack(self.was_ui_opened);
         }
 
-        if self.files_directory.is_empty() && !self.files_directory.is_empty() {
+        if self.source_file.is_empty() && !self.files_directory.is_empty() {
             // internally map the source_file and source_files_directory together
             self.source_file = format!("{}/{}", self.files_directory, self.source_file);
         }

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -53,7 +53,7 @@ fn benchmark() {
 
     cli.validate();
 
-    let input_files = get_input_files(cli.source_file.clone());
+    let input_files = get_input_files(cli.source_file.clone(), cli.files_directory.clone());
     let mut engine = BenchmarkEngine::new();
     // prepare permutations for the engine to run over
     for input in input_files {
@@ -250,20 +250,22 @@ fn get_bitrate_for(metadata: &MetaData, string: String) -> u32 {
     }
 }
 
-fn get_input_files(source_file: String) -> Vec<String> {
+fn get_input_files(source_file: String, source_files_directory: String) -> Vec<String> {
     if source_file.is_empty() {
         return get_supported_inputs()
             .iter()
-            .map(|s| map_file(is_dev(), s))
+            .map(|s| map_file(is_dev(), source_files_directory.clone(), s))
             .collect::<Vec<String>>();
     }
 
     return vec![source_file];
 }
 
-fn map_file(is_dev: bool, s: &&str) -> String {
+fn map_file(is_dev: bool, source_files_directory: String, s: &&str) -> String {
     let mut file = String::new();
-    if is_dev {
+    if !source_files_directory.is_empty() {
+        file.push_str(format!("{}/{}", source_files_directory, *s).as_str());
+    } else if is_dev {
         file.push_str("../");
         file.push_str(*s);
     } else {

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -1,5 +1,5 @@
-use std::{env, panic};
 use std::path::Path;
+use std::{env, panic};
 
 use clap::Parser;
 use text_io::read;

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -1,4 +1,5 @@
 use std::{env, panic};
+use std::path::Path;
 
 use clap::Parser;
 use text_io::read;
@@ -156,6 +157,38 @@ fn read_user_input(cli: &mut BenchmarkCli, gpus: Vec<String>) {
             }
 
             break;
+        }
+    }
+
+    // user may specify a directory for the source files
+    let mut in_current_dir = false;
+    loop {
+        print!("\nAre the source files in the current directory? [y/n]: ");
+        let in_current_directory: String = read!("{}");
+        if in_current_directory != "n" && in_current_directory != "y" {
+            println!("Invalid input, try again...");
+        } else {
+            if in_current_directory == "y" {
+                in_current_dir = true;
+            }
+
+            break;
+        }
+
+        break;
+    }
+
+    if !in_current_dir {
+        loop {
+            print!("\nPlease specify the input source file directory: ");
+            let source_files_directory: String = read!("{}");
+
+            if !(Path::new(source_files_directory.as_str()).exists()) {
+                print!("The provided directory does not exist, please check your input and try again...")
+            } else {
+                cli.files_directory = source_files_directory;
+                break;
+            }
         }
     }
 

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -55,7 +55,8 @@ fn benchmark() {
     cli.validate();
 
     let input_files = get_input_files(cli.source_file.clone(), cli.files_directory.clone());
-    let mut engine = BenchmarkEngine::new();
+    let mut engine = BenchmarkEngine::new(cli.log_output_directory.clone());
+
     // prepare permutations for the engine to run over
     for input in input_files {
         let mut permutation = Permutation::new(input, cli.encoder.clone());

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1,7 +1,7 @@
-use std::{env, fs};
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
+use std::{env, fs};
 
 use figlet_rs::FIGfont;
 

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1,8 +1,9 @@
-use figlet_rs::FIGfont;
+use std::{env, fs};
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
-use std::{env, fs};
+
+use figlet_rs::FIGfont;
 
 use environment::env::fail_if_environment_not_setup;
 
@@ -22,7 +23,6 @@ pub fn get_video_files(source_file_directory: &String) -> Vec<String> {
         "."
     };
 
-    println!("Using {} for looking up video files: ", locale);
     let paths = fs::read_dir(locale).unwrap();
     return paths
         .filter_map(|e| e.ok())

--- a/engine/src/benchmark_engine.rs
+++ b/engine/src/benchmark_engine.rs
@@ -11,13 +11,15 @@ use crate::threads::setup_ctrl_channel;
 pub struct BenchmarkEngine {
     permutations: Vec<Permutation>,
     results: Vec<PermutationResult>,
+    log_files_directory: String,
 }
 
 impl BenchmarkEngine {
-    pub fn new() -> Self {
+    pub fn new(log_files: String) -> Self {
         return Self {
             permutations: vec![],
             results: vec![],
+            log_files_directory: log_files,
         };
     }
 
@@ -44,6 +46,7 @@ impl BenchmarkEngine {
             Vec::new(),
             self.permutations[0].bitrate,
             true,
+            &self.log_files_directory,
         );
         println!("Benchmark runtime: {}", runtime_str);
     }

--- a/engine/src/permutation_engine.rs
+++ b/engine/src/permutation_engine.rs
@@ -30,17 +30,19 @@ pub struct PermutationEngine {
     results: Vec<PermutationResult>,
     dup_results: Vec<PermutationResult>,
     vmaf_scores: HashSet<String>,
+    log_files_directory: String,
 }
 
 // note: we can make 2 engines; benchmark engine, and the permutation engine
 // this way we can make the run() method a lot less complex
 impl PermutationEngine {
-    pub fn new() -> Self {
+    pub fn new(log_files: String) -> Self {
         return Self {
             permutations: vec![],
             results: vec![],
             dup_results: vec![],
             vmaf_scores: HashSet::new(),
+            log_files_directory: log_files,
         };
     }
 
@@ -77,7 +79,7 @@ impl PermutationEngine {
                     permutation.verbose,
                     i,
                 )
-                .expect("Failed to check encode quality");
+                    .expect("Failed to check encode quality");
 
                 result.vmaf_calculation_time = vmaf_start_time.elapsed().unwrap().as_secs();
 
@@ -124,6 +126,7 @@ impl PermutationEngine {
             self.dup_results.clone(),
             self.permutations[0].bitrate,
             false,
+            &self.log_files_directory,
         );
         println!("Benchmark runtime: {}", runtime_str);
     }

--- a/engine/src/permutation_engine.rs
+++ b/engine/src/permutation_engine.rs
@@ -79,7 +79,7 @@ impl PermutationEngine {
                     permutation.verbose,
                     i,
                 )
-                    .expect("Failed to check encode quality");
+                .expect("Failed to check encode quality");
 
                 result.vmaf_calculation_time = vmaf_start_time.elapsed().unwrap().as_secs();
 

--- a/engine/src/result.rs
+++ b/engine/src/result.rs
@@ -58,7 +58,7 @@ impl PermutationResult {
                 self.metadata.fps,
                 self.bitrate
             )
-            .as_str(),
+                .as_str(),
         );
 
         // adjust tabs based on expected vmaf score, or lack of one
@@ -88,7 +88,7 @@ impl PermutationResult {
                 self.fps_stats.ninety_perc,
                 effective_settings
             )
-            .as_str(),
+                .as_str(),
         );
 
         return default;
@@ -101,6 +101,7 @@ pub fn log_results_to_file(
     dup_results: Vec<PermutationResult>,
     bitrate: u32,
     is_benchmark: bool,
+    log_directory: &String,
 ) {
     // might make this naming here more robust eventually
     let first_metadata = results.get(0).unwrap().metadata;
@@ -111,13 +112,18 @@ pub fn log_results_to_file(
         first_metadata.get_res(),
         first_metadata.fps
     )
-    .to_string();
+        .to_string();
     let benchmark_file_name = format!("{}-benchmark.log", encoder).to_string();
-    let file_name = if is_benchmark {
+    let mut file_name = if is_benchmark {
         benchmark_file_name
     } else {
         permute_file_name
     };
+
+    // if an output directory was provided, we'll append that
+    if !log_directory.is_empty() {
+        file_name = format!("{}/{}", log_directory, file_name);
+    }
 
     let mut w = File::create(file_name).unwrap();
 

--- a/engine/src/result.rs
+++ b/engine/src/result.rs
@@ -58,7 +58,7 @@ impl PermutationResult {
                 self.metadata.fps,
                 self.bitrate
             )
-                .as_str(),
+            .as_str(),
         );
 
         // adjust tabs based on expected vmaf score, or lack of one
@@ -88,7 +88,7 @@ impl PermutationResult {
                 self.fps_stats.ninety_perc,
                 effective_settings
             )
-                .as_str(),
+            .as_str(),
         );
 
         return default;
@@ -112,7 +112,7 @@ pub fn log_results_to_file(
         first_metadata.get_res(),
         first_metadata.fps
     )
-        .to_string();
+    .to_string();
     let benchmark_file_name = format!("{}-benchmark.log", encoder).to_string();
     let mut file_name = if is_benchmark {
         benchmark_file_name

--- a/permutor-cli/src/main.rs
+++ b/permutor-cli/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
-use cli::cli_util::log_cli_header;
 
+use cli::cli_util::log_cli_header;
 use codecs::amf::Amf;
 use codecs::av1_qsv::AV1QSV;
 use codecs::get_vendor_for_codec;
@@ -22,7 +22,7 @@ fn main() {
 
     log_special_arguments(&cli);
 
-    let mut engine = PermutationEngine::new();
+    let mut engine = PermutationEngine::new(cli.log_output_directory.clone());
     let vendor = get_vendor_for_codec(&cli.encoder.clone());
     for bitrate in get_bitrate_permutations(cli.bitrate, cli.max_bitrate_permutation.unwrap()) {
         match vendor {

--- a/permutor-cli/src/permutor_cli.rs
+++ b/permutor-cli/src/permutor_cli.rs
@@ -25,7 +25,7 @@ pub struct PermutorCli {
     /// the directory you wish the benchmark to look for your encoder files; can be used with --source_file/-s if you wish
     #[arg(short, long, value_name = "folder/to/files", default_value = "")]
     pub files_directory: String,
-    /// the directory you wish for the logs this tool produces to go into; defaults to the current directory. Note: does not change the location of temporary log files (like the ones ffmpeg makes)
+    /// the directory you wish for the logs this tool produces to go into; defaults to the current directory. Does NOT support spaces in directories
     #[arg(long, value_name = "folder/to/log/output", default_value = "")]
     pub log_output_directory: String,
     /// runs just the first permutation for given encoder; useful for testing the tool & output

--- a/permutor-cli/src/permutor_cli.rs
+++ b/permutor-cli/src/permutor_cli.rs
@@ -61,7 +61,7 @@ impl PermutorCli {
             self.max_bitrate_permutation = Option::from(self.bitrate);
         }
 
-        if self.files_directory.is_empty() && !self.files_directory.is_empty() {
+        if self.source_file.is_empty() && !self.files_directory.is_empty() {
             // internally map the source_file and source_files_directory together
             self.source_file = format!("{}/{}", self.files_directory, self.source_file);
         }

--- a/permutor-cli/src/permutor_cli.rs
+++ b/permutor-cli/src/permutor_cli.rs
@@ -22,6 +22,9 @@ pub struct PermutorCli {
     /// the source file you wish to benchmark; if not provided, will run standard benchmark on all supported resolutions
     #[arg(short, long, value_name = "source.y4m", default_value = "")]
     pub source_file: String,
+    /// the directory you wish the benchmark to look for your encoder files; can be used with --source_file/-s if you wish
+    #[arg(short, long, value_name = "folder/to/files", default_value = "")]
+    pub files_directory: String,
     /// runs just the first permutation for given encoder; useful for testing the tool & output
     #[arg(short, long)]
     pub test_run: bool,
@@ -45,6 +48,7 @@ impl PermutorCli {
             self.list_supported_encoders,
             &self.encoder,
             &self.source_file,
+            &self.files_directory,
             false,
         );
 
@@ -55,6 +59,11 @@ impl PermutorCli {
 
         if self.max_bitrate_permutation.is_none() {
             self.max_bitrate_permutation = Option::from(self.bitrate);
+        }
+
+        if self.files_directory.is_empty() && !self.files_directory.is_empty() {
+            // internally map the source_file and source_files_directory together
+            self.source_file = format!("{}/{}", self.files_directory, self.source_file);
         }
     }
 

--- a/permutor-cli/src/permutor_cli.rs
+++ b/permutor-cli/src/permutor_cli.rs
@@ -25,6 +25,9 @@ pub struct PermutorCli {
     /// the directory you wish the benchmark to look for your encoder files; can be used with --source_file/-s if you wish
     #[arg(short, long, value_name = "folder/to/files", default_value = "")]
     pub files_directory: String,
+    /// the directory you wish for the logs this tool produces to go into; defaults to the current directory. Note: does not change the location of temporary log files (like the ones ffmpeg makes)
+    #[arg(long, value_name = "folder/to/log/output", default_value = "")]
+    pub log_output_directory: String,
     /// runs just the first permutation for given encoder; useful for testing the tool & output
     #[arg(short, long)]
     pub test_run: bool,


### PR DESCRIPTION
Addresses #19

You can now change the source directory you want to use for encoding video files!

Plus you can change the location of where the log files this tool makes go.