### PR TITLE
Adding in Apple silicon support (partial)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,12 @@
 - [Permutor Cli Quick Run Guide](#permutor-cli-quick-run-guide)
 - [Permutor Cli Common Commands and Use Cases](#permutor-cli-common-commands-and-use-cases)
 - [Contributing](#contributing)
+- [Building the Entire Tool Locally and Running](#building-the-entire-tool-locally-and-running)
+- [Adding Support for New Encoder](#adding-support-for-new-encoders)
+- [Troubleshooting](#troubleshooting)
 
-If you are curious on research findings or other nitty-gritty details about this project, see the project's <a href='https://github.com/Proryanator/encoder-benchmark/wiki'>wiki</a>.
+If you are curious on research findings or other nitty-gritty details about this project, see the
+project's <a href='https://github.com/Proryanator/encoder-benchmark/wiki'>wiki</a>.
 
 ## Overview
 
@@ -100,17 +104,21 @@ it's highly suggested to use the same version, or at least version `6.*` of ffmp
 
     - For Windows, recommend downloading the binaries for Windows from <a href='https://www.gyan.dev/ffmpeg/builds/'>
       gyan.dev</a>, specifically the `ffmpeg-release-full` one, which should include all needed features and tools
-    - For Mac/Linux, install both `ffmpeg` and `ffprobe` at mentioned versions above
+    - For Mac, recommended to install via `brew install ffmpeg` (will install ffpmpeg and ffprobe)
+    - For Linux, recommended to install using your distro's package manager. Note: the default one may be a much lower
+      version than `6.0` and may require more setup
 2) <a href='https://www.7-zip.org/download.html'>7-Zip</a> to unzip any downloaded ffmpeg binaries
 3) ffmpeg/ffprobe must be available on your path (tool will error out if it can't find
    either); <a href='https://www.architectryan.com/2018/03/17/add-to-the-path-on-windows-10/'>quick path setup guide for
    Windows
-   10+</a>. Note: when following those instructions do make sure to add the `ffmpeg_folder\bin` directory to your path (any other directory will not work)
+   10+</a>. Note: when following those instructions do make sure to add the `ffmpeg_folder\bin` directory to your path (
+   any other directory will not work)
 4) Download either the **benchmark** tool or the **permutor** tool (depending on your use case) for your platform from
    the <a href='https://github.com/Proryanator/encoder-benchmark/releases'>release section</a> of this repo onto the SSD
    that you wish to run the benchmark on
 5) Download the source files
-   from <a href='https://utsacloud-my.sharepoint.com/:f:/g/personal/hlz000_utsa_edu/EgkZZbJam-pAveNLTapnaOYB8gOvyx2naqV9NyIDb5c03A?e=hIfmLH'>here</a> (you may need to
+   from <a href='https://utsacloud-my.sharepoint.com/:f:/g/personal/hlz000_utsa_edu/EgkZZbJam-pAveNLTapnaOYB8gOvyx2naqV9NyIDb5c03A?e=hIfmLH'>
+   here</a> (you may need to
    download individual files if the .zip is too large)
 6) Extract all the source files to the target SSD you wish to read the files form (same folder as the tool)
 
@@ -282,26 +290,104 @@ Screenshots or log file uploads are much appreciated!
 
 ## Contributing
 
-This project welcomes any and all contributors! Especially those interested in adding Linux support. Feel free to assign issues to yourself, start discussions, or reach out to the author in his Discord server <a href='https://discord.gg/pgFmZgRxUU'>here</a>.
+This project welcomes any and all contributors! Especially those interested in adding Linux support. Feel free to assign
+issues to yourself, start discussions, or reach out to the author in his Discord
+server <a href='https://discord.gg/pgFmZgRxUU'>here</a>.
 
 ### Rust Version
+
 Project is written in Rust, with version `1.73.0` at time of writing.
 
 ### RustRover IDE (suggested by Author)
 
-The author uses <a href='https://www.jetbrains.com/rust/'>RustRover</a> for most of his Rust development, although you're more than welcome to use other IDE's.
+The author uses <a href='https://www.jetbrains.com/rust/'>RustRover</a> for most of his Rust development, although
+you're more than welcome to use other IDE's.
 
 #### Setting up automatic formatting via rustfmt in RustRover
+
 It's suggested that you setup automatic formatting in RustRover to avoid the `rustfmt` job failing and blocking your PR.
 
-Go to Settings -> Languages and Frameworks -> Rust -> Rustfmt, and enable `Use Rustfmt instead of the build-in formatter` and `Run Rustfmt automatically on Save`.
+Go to Settings -> Languages and Frameworks -> Rust -> Rustfmt, and
+enable `Use Rustfmt instead of the build-in formatter` and `Run Rustfmt automatically on Save`.
 
 ![rustrover-rustfmt.png](docs%2Frustrover-rustfmt.png)
 
 ### Visual Studio Code
 
-You can also use VSCode if you want when contributing to the project. Make sure you have the plugin <a href='https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer'>rust-analyzer</a> which seems to already have a built-in formatter for rust.
+You can also use VSCode if you want when contributing to the project. Make sure you have the
+plugin <a href='https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer'>rust-analyzer</a> which
+seems to already have a built-in formatter for rust.
 
 Just make sure you enable formatting on save via `Settings -> Search for 'format' -> toggle 'Editor: Format On Save'`
 
 ![vscode-auto-format.png](docs%2Fvscode-auto-format.png)
+
+### Building the Entire Tool Locally and Running
+
+Sometimes the terminal in your IDE may not render the results the best, so you may want to run a full
+permutation/benchmark in the background. Here's how to build the tool and do just that.
+
+1. Run `cargo build --release` to generate the binaries
+2. Run `./target/release/permutor-cli` or `./target/release/benchmark` respectively (adjust with `.exe` for Windows)
+
+### Adding Support for New Encoders
+
+To help with onboarding new encoders/vendors (and know how existing ones are supported), here is a step-by-step guide to
+adding support for a new encoder:
+
+#### Adding in CLI Support for the Encoder
+
+This will make the cli tool aware of the new encoder.
+
+1. Add a new entry into the file `cli/src/supported.rs` matching the string of the `encoder=` argument usually provided
+   to ffmpeg, i.e. `h264_nvenc` is the string used by ffmpeg to use the Nvidia H264 encoder
+2. Add a new entry into the file `codecs/src/vendor.rs` and update any references to the Vendor in the project to use
+   the newly added one (named whatever matches the vendor/manufacturer of the GPU/CPU), i.e. `Nvidia`, `AMD`, etc.
+3. Update a method called `get_vendor_for_codec` that maps the ffmpeg `encoder=` string to the new Vendor that was
+   added, in `codecs/src/lib.rs`
+4. Add a new method in `permutor-cli/src/main.rs` that will be used to init the encoder's permutation (see any of the
+   existing methods at the bottom).
+5. Update the `main` method in `permutor-cli/src/main.rs` to now call your newly added init() method depending on the
+   vendor
+
+#### Implementing the Permutation Engine for the Encoder
+
+Now that the cli tool is aware of the new encoder, we still need to add in some custom logic for building ffmpeg
+arguments specific to this encoder. We'll do that now.
+
+1. Add a new file, properly named based on your encoder, under `codecs/src` (feel free to copy any of the other files)
+2. Using what options you see from `ffmpeg -h encoder=encoder_name`, fill out the various structs of data
+3. Update the methods that build the permutations, including ones that provide a standardized ffmpeg permutation (this
+   is what would be used by the benchmark portion of this tool)
+
+#### Checklist for Fully Functional Implementation
+
+These things should be checked to make sure that the newly added encoder works as designed:
+
+1. All permutations should run w/o consistent failures (to check for any ffmpeg errors when trying to run a permutation)
+2. Verify that the new encoder can correctly generate a VMAF score by using the `-c` flag
+3. You have set (even if a placeholder) a benchmark encoding permutation to use
+4. Verify that you are able to run a benchmark for your given newly added encoder
+5. Verify your new encoder also works when decoding as part of the benchmark run (just in case) via the `-d` argument
+6. As part of running permutations, determining the bitrate that provides lossless quality for a given resolution is
+   important. After running through bitrate permutations (by using `-m` and providing a bitrate maximum range to test
+   with). Once you know a good bitrate for a specific encoder/resolution, you'll want to add that mapping into the
+   encoder's file function `get_resolution_to_bitrate_map`
+
+#### Deciding What Arguments to Use for Benchmarking Tool
+
+Since the benchmark part of this project is intended to maximize FPS performance, you'll want
+to hand-select the best performing encoder arguments based on running full permutations on your encoder.
+
+An example of what the author did for the nvenc_h264 encoder:
+
+1. Ran a full permutation of all available nvenc_h264 encoder settings, producing an output file of statistics
+2. Identified a handful (usually there's not just 1) of encoder setting permutations that produces the highest fps
+3. Those encoder settings are then set as the default benchmark settings
+
+### Troubleshooting
+
+<i>Error about unsupported feature</i>
+
+If you are getting the following: `#![feature] may not be used on the stable release channel`, this should be fixable by
+running `cargo clean`.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,12 @@ supported.
 - ***AMD H264/HEVC** (h264_amf, hevc_amf)
 - **Intel Quick Sync Video H264/HEVC** (h264_qsv, hevc_qsv)
 - ***Intel Arc AV1** (av1_qsv)
-- **Apple Silicon H264/HEVC (h264_videotoolbox, hevc_videotoolbox)**
+- **Apple Silicon H264/HEVC permutations (h264_videotoolbox, hevc_videotoolbox)**
+
+The following have code in the project to 'support it' but currently <i>do not</i> function correctly.
+
+- **Apple Silicon Benchmarks of Any Kind** (just don't work right now)
+- **Apple Silicon ProRes (prores_videotoolbox)**
 
 ## Minimum system specs suggested
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ The following have code in the project to 'support it' but currently <i>do not</
 
 ## Minimum system specs suggested
 
-- <b>OS:</b> Windows (will support more OS's eventually)
-- <b>Processor:</b> CPU with at least 6 cores
+- <b>OS:</b> Windows, Mac or Linux
+- <b>Processor:</b> CPU with at least 6 cores (for macbooks, Intel _should_ work, but Apple Silicon for sure has been tested)
 - <b>GPU:</b> Nvidia GPU w/ a hardware encoder, in the main x16 PCI slot of your PC (for max PCI bandwidth)
 - <b>Memory:</b> >= 8GB RAM (higher is always better)
 - <b>Storage Space:</b> 3-12GB depending on target resolution/framerate, 90GB for the full benchmark
@@ -86,7 +86,7 @@ A nice cross-platform tool to test your SSD's sequential read speeds: <a href='h
 Bench</a>
 
 Note: the tool _does_ support selecting a specific GPU in your system if you have more than one, but you may experience
-PCI bottlenecking for GPU's not in the primary slot.
+PCI bottlen-ecking for GPU's not in the primary slot.
 
 ### Important notes about your system
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ supported.
 - ***AMD H264/HEVC** (h264_amf, hevc_amf)
 - **Intel Quick Sync Video H264/HEVC** (h264_qsv, hevc_qsv)
 - ***Intel Arc AV1** (av1_qsv)
+- **Apple Silicon H264/HEVC (h264_videotoolbox, hevc_videotoolbox)**
 
 ## Minimum system specs suggested
 
@@ -349,6 +350,7 @@ This will make the cli tool aware of the new encoder.
    existing methods at the bottom).
 5. Update the `main` method in `permutor-cli/src/main.rs` to now call your newly added init() method depending on the
    vendor
+6. Update `Supported Encoders` section of the readme for full transparency of the supported encoders
 
 #### Implementing the Permutation Engine for the Encoder
 

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -1,5 +1,5 @@
-use std::{env, panic};
 use std::path::Path;
+use std::{env, panic};
 
 use clap::Parser;
 use text_io::read;

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -1,5 +1,5 @@
-use std::path::Path;
 use std::{env, panic};
+use std::path::Path;
 
 use clap::Parser;
 use text_io::read;
@@ -7,6 +7,7 @@ use text_io::read;
 use cli::cli_util::{is_dev, log_cli_header, pause};
 use cli::supported::{get_supported_encoders, get_supported_inputs};
 use codecs::amf::Amf;
+use codecs::apple_silicon::Apple;
 use codecs::av1_qsv::AV1QSV;
 use codecs::get_vendor_for_codec;
 use codecs::nvenc::Nvenc;
@@ -263,6 +264,18 @@ fn get_benchmark_settings_for(cli: &BenchmarkCli) -> String {
             } else {
                 let intel_qsv = QSV::new(cli.encoder == "hevc_qsv");
                 intel_qsv.get_benchmark_settings()
+            }
+        }
+        Vendor::Apple => {
+            if cli.encoder.contains("h264") {
+                let apple = Apple::new(true, false);
+                apple.get_benchmark_settings()
+            } else if cli.encoder.contains("hevc") {
+                let apple_h264 = Apple::new(false, false);
+                apple_h264.get_benchmark_settings()
+            } else {
+                let apple_h264 = Apple::new(false, true);
+                apple_h264.get_benchmark_settings()
             }
         }
         Vendor::Unknown => {

--- a/cli/src/supported.rs
+++ b/cli/src/supported.rs
@@ -8,7 +8,7 @@ const SUPPORTED_ENCODERS: [&'static str; 10] = [
     "av1_qsv",
     "h264_videotoolbox",
     "hevc_videotoolbox",
-    "prores_videotoolbox"
+    "prores_videotoolbox",
 ];
 
 const ENCODE_FILES: [&'static str; 8] = [

--- a/cli/src/supported.rs
+++ b/cli/src/supported.rs
@@ -1,4 +1,4 @@
-const SUPPORTED_ENCODERS: [&'static str; 7] = [
+const SUPPORTED_ENCODERS: [&'static str; 10] = [
     "h264_nvenc",
     "hevc_nvenc",
     "h264_amf",
@@ -6,6 +6,9 @@ const SUPPORTED_ENCODERS: [&'static str; 7] = [
     "h264_qsv",
     "hevc_qsv",
     "av1_qsv",
+    "h264_videotoolbox",
+    "hevc_videotoolbox",
+    "prores_videotoolbox"
 ];
 
 const ENCODE_FILES: [&'static str; 8] = [
@@ -23,7 +26,7 @@ pub fn is_encoder_supported(potential_encoder: &String) -> bool {
     return SUPPORTED_ENCODERS.contains(&potential_encoder.as_str());
 }
 
-pub fn get_supported_encoders() -> [&'static str; 7] {
+pub fn get_supported_encoders() -> [&'static str; 10] {
     return SUPPORTED_ENCODERS;
 }
 

--- a/codecs/src/apple_silicon.rs
+++ b/codecs/src/apple_silicon.rs
@@ -1,0 +1,219 @@
+use std::collections::HashMap;
+
+use itertools::Itertools;
+
+use crate::permute::Permute;
+use crate::resolutions::map_res_to_bitrate;
+
+// TODO: add in values to permutation for -realtime, -prio_speed
+// all available encoders, h264, hevc, and prores have similar shared options other than profiles
+// note: level does not appear to be supported and throws errors
+pub struct Apple {
+    profiles: Vec<&'static str>,
+    coders: Vec<&'static str>,
+    // might be able to make this the size we're expecting
+    permutations: Vec<String>,
+    is_h264: bool,
+    is_prores: bool,
+    index: i32,
+}
+
+impl Apple {
+    // note: h264 has a unique coders option
+    pub fn new(is_h264: bool, is_prores: bool) -> Self {
+        Self {
+            profiles: if is_h264 {
+                vec![
+                    "baseline",
+                    "constrained_baseline",
+                    "main",
+                    "high",
+                    "constrained_high",
+                    "extended",
+                ]
+            } else if is_prores {
+                vec!["auto", "proxy", "lt", "standard", "hq", "4444", "xq"]
+            } else {
+                vec!["main", "main10"]
+            },
+            // note: only h264 has the coders option
+            coders: if is_h264 {
+                vec!["vlc", "cavlc", "cabac", "ac"]
+            } else {
+                vec![]
+            },
+            permutations: Vec::new(),
+            is_h264,
+            is_prores,
+            // starts at -1, so that first next() will return the first element
+            index: -1,
+        }
+    }
+
+    pub fn get_benchmark_settings(&self) -> String {
+        return if self.is_h264 {
+            String::from("-profile:v baseline -coder vlc -constant_bit_rate true ")
+        } else if self.is_prores {
+            String::from("-profile:v auto ")
+        } else {
+            String::from("-profile:v main -constant_bit_rate true ")
+        };
+    }
+
+    fn has_next(&self) -> bool {
+        return self.index != (self.permutations.len() - 1) as i32;
+    }
+}
+
+#[derive(Copy, Clone)]
+struct AppleSettings {
+    profile: &'static str,
+    coder: &'static str,
+    is_prores: bool,
+}
+
+impl AppleSettings {
+    fn to_string(&self) -> String {
+        let mut args = String::new();
+        args.push_str("-profile:v ");
+        args.push_str(self.profile);
+
+        // hevc does not support this, so this will be empty for hevc
+        if !self.coder.is_empty() {
+            args.push_str(" -coder ");
+            args.push_str(self.coder);
+        }
+
+        // prores does not have/support constant bit rate
+        if !self.is_prores {
+            args.push_str(" -constant_bit_rate");
+            args.push_str(" true");
+        }
+
+        return args;
+    }
+}
+
+impl Iterator for Apple {
+    type Item = (usize, String);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if !self.has_next() {
+            return None;
+        }
+
+        self.index += 1;
+
+        let usize_index = self.index as usize;
+        return Option::from((
+            usize_index as usize,
+            self.permutations.get(usize_index).unwrap().to_string(),
+        ));
+    }
+}
+
+impl Permute for Apple {
+    fn init(&mut self) -> &Vec<String> {
+        // reset index, otherwise we won't be able to iterate at all
+        self.index = -1;
+
+        // clear the vectors if there were entries before
+        self.permutations.clear();
+
+        let vectors = if self.is_h264 {
+            vec![&self.profiles, &self.coders]
+        } else {
+            vec![&self.profiles]
+        };
+        let mut permutations = vectors.into_iter().multi_cartesian_product();
+
+        loop {
+            let perm = permutations.next();
+            if perm.is_none() {
+                break;
+            }
+
+            let unwrapped_perm = perm.unwrap();
+            let settings = AppleSettings {
+                profile: unwrapped_perm.get(0).unwrap(),
+                coder: if self.is_h264 {
+                    unwrapped_perm.get(1).unwrap()
+                } else {
+                    ""
+                },
+                is_prores: self.is_prores,
+            };
+
+            self.permutations.push(settings.to_string());
+        }
+
+        return &self.permutations;
+    }
+
+    fn run_standard_only(&mut self) -> &Vec<String> {
+        // reset index, otherwise we won't be able to iterate at all
+        self.index = -1;
+
+        // clear the vectors if there were entries before
+        self.permutations.clear();
+
+        // note: this only works when hevc/h264 both use just 1 profile, if we add more this will break
+        self.permutations
+            .push(String::from(self.get_benchmark_settings()));
+        return &self.permutations;
+    }
+
+    fn get_resolution_to_bitrate_map(fps: u32) -> HashMap<String, u32> {
+        let mut map: HashMap<String, u32> = HashMap::new();
+
+        // TODO: need to update this for apple silicon
+        let mut bitrates: [u32; 4] = [10, 20, 25, 55];
+
+        // 120 fps is effectively double the bitrate
+        if fps == 120 {
+            bitrates.iter_mut().for_each(|b| *b = *b * 2);
+        }
+
+        map_res_to_bitrate(&mut map, bitrates);
+
+        return map;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::apple_silicon::Apple;
+    use crate::permute::Permute;
+
+    #[test]
+    fn create_h264_test() {
+        let apple_h264 = Apple::new(true, false);
+        assert!(apple_h264.profiles.contains(&"constrained_baseline"));
+    }
+
+    #[test]
+    fn create_hevc_test() {
+        let apple_h264 = Apple::new(false, false);
+        assert!(apple_h264.profiles.contains(&"main10"));
+    }
+
+    #[test]
+    fn create_prores_test() {
+        let apple_h264 = Apple::new(false, true);
+        assert!(apple_h264.profiles.contains(&"lt"));
+    }
+
+    #[test]
+    fn iterate_to_end_test() {
+        let mut apple = Apple::new(false, false);
+        let perm_count = apple.init().len();
+
+        let mut total = 0;
+        while let Some((_usize, _string)) = apple.next() {
+            total += 1
+        }
+
+        // determine if we iterated over all the permutations correctly
+        assert_eq!(total, perm_count);
+    }
+}

--- a/codecs/src/lib.rs
+++ b/codecs/src/lib.rs
@@ -1,13 +1,13 @@
 use crate::vendor::Vendor;
 
 pub mod amf;
+pub mod apple_silicon;
 pub mod av1_qsv;
 pub mod nvenc;
 pub mod permute;
 pub mod qsv;
 mod resolutions;
 pub mod vendor;
-pub mod apple_silicon;
 
 pub fn get_vendor_for_codec(codec: &String) -> Vendor {
     if codec.contains("nvenc") {

--- a/codecs/src/lib.rs
+++ b/codecs/src/lib.rs
@@ -7,6 +7,7 @@ pub mod permute;
 pub mod qsv;
 mod resolutions;
 pub mod vendor;
+pub mod apple_silicon;
 
 pub fn get_vendor_for_codec(codec: &String) -> Vendor {
     if codec.contains("nvenc") {
@@ -16,6 +17,8 @@ pub fn get_vendor_for_codec(codec: &String) -> Vendor {
     } else if codec.contains("h264_qsv") || codec.contains("hevc_qsv") || codec.contains("av1_qsv")
     {
         return Vendor::IntelQSV;
+    } else if codec.contains("videotoolbox") {
+        return Vendor::Apple;
     }
 
     return Vendor::Unknown;

--- a/codecs/src/vendor.rs
+++ b/codecs/src/vendor.rs
@@ -2,5 +2,6 @@ pub enum Vendor {
     Nvidia,
     AMD,
     IntelQSV,
+    Apple,
     Unknown,
 }

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -203,6 +203,7 @@ fn run_overload_benchmark(
     if trial_result.ffmpeg_error && !was_ctrl_c_received(&ctrl_channel) {
         let _ = child.kill();
         eprintln!("Ffmpeg encountered an error when attempting to run, double-check that your environment is setup correctly. If so, open an issue in github!");
+        eprintln!("See below re-creation of the ffmpeg error...");
         // spawn the ffmpeg command, with output logged so we can troubleshoot better
         // modifying the command just a little bit so that it fails immediately
         let mut child = spawn_ffmpeg_child(&ffmpeg_args, verbose, Option::from(true));

--- a/engine/src/permutation_engine.rs
+++ b/engine/src/permutation_engine.rs
@@ -225,7 +225,11 @@ fn calc_vmaf_score(
     let vmaf_log_file = get_latest_ffmpeg_report_file();
     // TODO: this does fix the issue for apple however, this may not scale very well across other vendors
     // or the output line number may have changed recently where we'll need to make this not dependent on line numbers at all
-    let line_number = if encoder_args.encoder.contains("videotoolbox") {15} else {3};
+    let line_number = if encoder_args.encoder.contains("videotoolbox") {
+        15
+    } else {
+        3
+    };
     let vmaf_score_line = read_last_line_at(line_number);
     //Cleanup process
     encoder_child

--- a/engine/src/permutation_engine.rs
+++ b/engine/src/permutation_engine.rs
@@ -120,6 +120,7 @@ impl PermutationEngine {
 
         // produce output files and other logging here
         let runtime_str = format_dhms(runtime.elapsed().unwrap().as_secs());
+
         log_results_to_file(
             self.results.clone(),
             &runtime_str,
@@ -222,7 +223,10 @@ fn calc_vmaf_score(
     println!("VMAF calculation finishing up...");
     let vmaf_child_status = vmaf_child.wait().expect("Vmaf child could not wait");
     let vmaf_log_file = get_latest_ffmpeg_report_file();
-    let vmaf_score_line = read_last_line_at(3);
+    // TODO: this does fix the issue for apple however, this may not scale very well across other vendors
+    // or the output line number may have changed recently where we'll need to make this not dependent on line numbers at all
+    let line_number = if encoder_args.encoder.contains("videotoolbox") {15} else {3};
+    let vmaf_score_line = read_last_line_at(line_number);
     //Cleanup process
     encoder_child
         .kill()

--- a/ffmpeg/src/args.rs
+++ b/ffmpeg/src/args.rs
@@ -102,6 +102,8 @@ impl FfmpegArgs {
                 Vendor::Nvidia => "cuda",
                 Vendor::AMD => "d3d11va",
                 Vendor::IntelQSV => "qsv",
+                // TODO: implement this
+                Vendor::Apple => "apple",
                 Vendor::Unknown => "error",
             };
 


### PR DESCRIPTION
Resolves #40 

Added in support for:

- h264/hevc encoding on apple silicon GPU's (encoding only for permutation)
- not fully supported pro res encoding