### PR TITLE
Fixing rust build jobs

### DIFF
--- a/.github/workflows/setup-and-build.yml
+++ b/.github/workflows/setup-and-build.yml
@@ -17,9 +17,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Rust
-        uses: ATiltedTree/setup-rust@v1
+        uses: actions-rs/toolchain@v1
         with:
-          rust-version: 1.73.0
+          toolchain: 1.73.0
 
       - name: Build
         run:


### PR DESCRIPTION
Would fix issue #61 where rust builds no longer work due to a dependent repo disappearing from github.