### PR TITLE
Fixed problem with permutor-cli crashing when finding VMAF score.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ tmp.flf
 
 # ignore tmp files created from unit tests
 ffmpeg/*log*
+
+# ignore Visual Studio Code configuration files
+.vscode/

--- a/codecs/src/nvenc.rs
+++ b/codecs/src/nvenc.rs
@@ -37,7 +37,7 @@ impl Nvenc {
 
     pub fn get_benchmark_settings(&self) -> String {
         return format!(
-            "-preset p1 -tune ll -profile:v {} -rc cbr -cbr true -gpu {}",
+            "-preset p1 -tune ll -profile:v {} -gpu {}",
             self.profiles.get(0).unwrap(),
             self.gpu
         );
@@ -75,15 +75,15 @@ impl NvencSettings {
         args.push_str(self.tune);
         args.push_str(" -profile:v ");
         args.push_str(self.profile);
-        args.push_str(" -rc ");
-        args.push_str(self.rate_control);
+        //args.push_str(" -rc ");
+        //args.push_str(self.rate_control);
         // user may have opted out of using b frames
         if self.no_b_frame {
             args.push_str(" -b_ref_mode 0");
         }
 
         // always set this to constant bit rate to ensure reliable stream
-        args.push_str(" -cbr true");
+        //args.push_str(" -cbr true");
         args.push_str(" -gpu ");
         args.push_str(self.gpu.to_string().as_str());
 

--- a/engine/src/benchmark_engine.rs
+++ b/engine/src/benchmark_engine.rs
@@ -44,7 +44,7 @@ impl BenchmarkEngine {
             self.results.clone(),
             &runtime_str,
             Vec::new(),
-            self.permutations[0].bitrate,
+            self.permutations[0].quality,
             true,
             &self.log_files_directory,
         );

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -9,7 +9,7 @@ use crossbeam_channel::Receiver;
 use ctrlc::Error;
 
 use cli::cli_util::error_with_ack;
-use ffmpeg::args::FfmpegArgs;
+use ffmpeg::args::{FfmpegArgs, FfmpegQuality};
 use ffmpeg::metadata::MetaData;
 use permutation::permutation::Permutation;
 
@@ -24,7 +24,7 @@ pub fn run_encode(
 ) -> PermutationResult {
     let mut result = PermutationResult::new(
         &p.get_metadata(),
-        p.bitrate,
+        p.quality,
         &p.encoder_settings,
         &p.encoder,
         p.decode_run,
@@ -36,7 +36,7 @@ pub fn run_encode(
         p.video_file,
         p.encoder,
         &p.encoder_settings,
-        p.bitrate,
+        p.quality,
         p.decode_run,
         p.ten_bit,
     );
@@ -143,7 +143,11 @@ fn log_header(
     println!("[Resolution:\t{}x{}]", metadata.width, metadata.height);
     println!("[Encoder:\t{}]", permutation.encoder);
     println!("[FPS:\t\t{}]", metadata.fps);
-    println!("[Bitrate:\t{}Mb/s]", permutation.bitrate);
+    //println!("[Bitrate:\t{}Mb/s]", permutation.quality);
+    match permutation.quality {
+        FfmpegQuality::ConstantBitrate(b) => println!("[Bitrate:\t{}Mb/s]", b),
+        FfmpegQuality::ConstantQuality(q) => println!("[Quality:\t{}]", q),
+    }
     println!("[{}]", permutation.encoder_settings);
 }
 

--- a/engine/src/permutation_engine.rs
+++ b/engine/src/permutation_engine.rs
@@ -93,7 +93,7 @@ impl PermutationEngine {
             }
 
             let is_initial_bitrate_permutation_over = i == self.permutations.len() - 1
-                || self.permutations[i + 1].clone().bitrate != permutation.bitrate;
+                || self.permutations[i + 1].clone().quality != permutation.quality;
             self.add_result(
                 result,
                 is_initial_bitrate_permutation_over,
@@ -125,7 +125,7 @@ impl PermutationEngine {
             self.results.clone(),
             &runtime_str,
             self.dup_results.clone(),
-            self.permutations[0].bitrate,
+            self.permutations[0].quality.clone(),
             false,
             &self.log_files_directory,
         );
@@ -175,7 +175,7 @@ fn calc_vmaf_score(
         p.video_file.clone(),
         p.encoder.clone(),
         &p.encoder_settings,
-        p.bitrate.clone(),
+        p.quality.clone(),
         p.decode_run,
         p.ten_bit,
     );

--- a/engine/src/permutation_engine.rs
+++ b/engine/src/permutation_engine.rs
@@ -8,7 +8,7 @@ use crossbeam_channel::Receiver;
 use ctrlc::Error;
 
 use ffmpeg::args::FfmpegArgs;
-use ffmpeg::report_files::{extract_vmaf_score, get_latest_ffmpeg_report_file, read_last_line_at, find_and_extract_vmaf_score};
+use ffmpeg::report_files::{get_latest_ffmpeg_report_file, read_last_line_at, find_and_extract_vmaf_score};
 use permutation::permutation::Permutation;
 
 use crate::engine::{log_permutation_header, run_encode, spawn_ffmpeg_child};

--- a/engine/src/result.rs
+++ b/engine/src/result.rs
@@ -5,6 +5,7 @@ use std::io::Write;
 use compound_duration::format_dhms;
 
 use ffmpeg::metadata::MetaData;
+use ffmpeg::args::FfmpegQuality;
 
 use crate::fps_stats::FpsStats;
 
@@ -12,7 +13,8 @@ use crate::fps_stats::FpsStats;
 pub struct PermutationResult {
     pub encoder: String,
     pub was_overloaded: bool,
-    bitrate: u32,
+    //bitrate: u32,
+    quality: FfmpegQuality,
     metadata: MetaData,
     pub encoder_settings: String,
     // only if the encodes were successful
@@ -26,7 +28,8 @@ pub struct PermutationResult {
 impl PermutationResult {
     pub fn new(
         metadata: &MetaData,
-        bitrate: u32,
+        //bitrate: u32,
+        quality: FfmpegQuality,
         encoder_settings: &String,
         encoder: &str,
         decode: bool,
@@ -34,7 +37,7 @@ impl PermutationResult {
         Self {
             encoder: String::from(encoder),
             was_overloaded: false,
-            bitrate,
+            quality,
             metadata: metadata.clone(),
             encoder_settings: encoder_settings.to_string(),
             encode_time: 0,
@@ -50,14 +53,26 @@ impl PermutationResult {
 
         let overloaded_indicator = if self.was_overloaded { "[O]" } else { "   " };
         default.push_str(
-            format!(
-                "{}{}x{}\t{}\t{}Mb/s",
-                overloaded_indicator,
-                self.metadata.width,
-                self.metadata.height,
-                self.metadata.fps,
-                self.bitrate
-            )
+            match self.quality {
+                FfmpegQuality::ConstantBitrate(bitrate) =>
+                    format!(
+                        "{}{}x{}\t{}\t{}Mb/s",
+                        overloaded_indicator,
+                        self.metadata.width,
+                        self.metadata.height,
+                        self.metadata.fps,
+                        bitrate,
+                    ),
+                FfmpegQuality::ConstantQuality(quality) =>
+                    format!(
+                        "{}{}x{}\t{}\t{}CQ",
+                        overloaded_indicator,
+                        self.metadata.width,
+                        self.metadata.height,
+                        self.metadata.fps,
+                        quality,
+                    ),
+        }
             .as_str(),
         );
 
@@ -99,7 +114,8 @@ pub fn log_results_to_file(
     results: Vec<PermutationResult>,
     runtime_str: &String,
     dup_results: Vec<PermutationResult>,
-    bitrate: u32,
+    //bitrate: u32,
+    quality: FfmpegQuality,
     is_benchmark: bool,
     log_directory: &String,
 ) {
@@ -135,13 +151,16 @@ pub fn log_results_to_file(
     }
 
     writeln!(&mut w, "   [Resolution]\t[FPS]\t[Bitrate]\t{}\t[VMAF Time]\t[VMAF Score]\t[Average FPS]\t[1%'ile]\t[90%'ile]\t[Encoder Settings]", time).unwrap();
-    let mut current_bitrate = 0;
+    let mut current_quality = match results.get(0).unwrap().quality {
+        FfmpegQuality::ConstantBitrate(_) => FfmpegQuality::ConstantBitrate(0),
+        FfmpegQuality::ConstantQuality(_) => FfmpegQuality::ConstantQuality(0),
+    };
 
     for result in &results {
         // print a line split between bitrate permutations for improved readability
-        if !is_benchmark && current_bitrate != result.bitrate {
+        if !is_benchmark && current_quality != result.quality {
             writeln!(&mut w, "##################################################################################################################################################################").unwrap();
-            current_bitrate = result.bitrate;
+            current_quality = result.quality.clone();
         }
 
         writeln!(&mut w, "{}", result.to_string()).unwrap();
@@ -154,7 +173,7 @@ pub fn log_results_to_file(
     // log out the duplicated results so we can keep track of them
     let initial_perms: Vec<PermutationResult> = results
         .into_iter()
-        .filter(|res| res.bitrate == bitrate)
+        .filter(|res| res.quality == quality)
         .collect();
 
     // for each of these, collect the duplicates with the same score

--- a/ffmpeg/src/args.rs
+++ b/ffmpeg/src/args.rs
@@ -6,6 +6,25 @@ use codecs::vendor::Vendor;
 pub static TCP_LISTEN: &str = "tcp://localhost:2000?listen&listen_timeout=3000&timeout=1000000";
 pub static NO_OUTPUT: &str = "-f null -";
 
+#[derive(Clone, PartialEq, Debug, Copy)]
+pub enum FfmpegQuality {
+    ConstantBitrate(u32),
+    ConstantQuality(u32),
+}
+
+impl Default for FfmpegQuality {
+    fn default() -> Self { FfmpegQuality::ConstantBitrate(0) }
+}
+
+impl std::fmt::Display for FfmpegQuality {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            FfmpegQuality::ConstantBitrate(bitrate) => write!(f, "-cbr true -rc cbr -b:v {}M", bitrate),
+            FfmpegQuality::ConstantQuality(quality) => write!(f, "-cbr false -rc vbr -cq {}", quality),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct FfmpegArgs {
     fps_limit: u32,
@@ -13,7 +32,8 @@ pub struct FfmpegArgs {
     send_progress: bool,
     pub first_input: String,
     second_input: String,
-    pub bitrate: u32,
+    //pub bitrate: u32,
+    pub quality: FfmpegQuality,
     pub encoder: String,
     pub encoder_args: String,
     pub output_args: String,
@@ -31,7 +51,8 @@ impl Default for FfmpegArgs {
             send_progress: true,
             first_input: String::new(),
             second_input: String::new(),
-            bitrate: u32::default(),
+            //bitrate: u32::default(),
+            quality: FfmpegQuality::default(),
             encoder: String::new(),
             encoder_args: String::new(),
             output_args: NO_OUTPUT.to_string(),
@@ -50,13 +71,14 @@ impl FfmpegArgs {
         first_input: String,
         encoder: String,
         encoder_args: &String,
-        current_bitrate: u32,
+        current_quality: FfmpegQuality,
         decode: bool,
         ten_bit: bool,
     ) -> FfmpegArgs {
         let ffmpeg_args = FfmpegArgs {
             first_input,
-            bitrate: current_bitrate,
+            //bitrate: current_bitrate,
+            quality: current_quality,
             encoder,
             encoder_args: encoder_args.to_string(),
             decode,
@@ -141,7 +163,8 @@ impl FfmpegArgs {
             } else {
                 append_encode_only_args(
                     &mut output,
-                    self.bitrate,
+                    //self.bitrate,
+                    self.quality.clone(),
                     &self.encoder,
                     &self.encoder_args,
                 );
@@ -192,13 +215,17 @@ impl FfmpegArgs {
 
 fn append_encode_only_args(
     arg_str: &mut String,
-    bitrate: u32,
+    //bitrate: u32,
+    quality: FfmpegQuality,
     encoder: &String,
     encoder_args: &String,
 ) {
-    arg_str.push_str([" -b:v", bitrate.to_string().as_str()].join(" ").as_str());
+    //arg_str.push_str([" -b:v", quality.to_string().as_str()].join(" ").as_str());
     // adding the rate amount to the end of the bitrate
-    arg_str.push('M');
+    //arg_str.push('M');
+
+    arg_str.push(' ');
+    arg_str.push_str(quality.to_string().as_str());
     arg_str.push_str([" -c:v", encoder.as_str()].join(" ").as_str());
     arg_str.push(' ');
     arg_str.push_str(encoder_args.as_str());
@@ -217,7 +244,8 @@ fn append_vmaf_only_args(arg_str: &mut String) {
 // TODO: get rid of this later
 pub struct Cli {
     pub encoder: String,
-    pub bitrate: u32,
+    //pub bitrate: u32,
+    pub quality: FfmpegQuality,
     pub check_quality: bool,
     pub detect_overload: bool,
     pub source_file: String,
@@ -230,11 +258,11 @@ pub struct Cli {
 
 #[cfg(test)]
 mod tests {
-    use crate::args::{Cli, FfmpegArgs, NO_OUTPUT, TCP_LISTEN};
+    use crate::args::{Cli, FfmpegArgs, FfmpegQuality, NO_OUTPUT, TCP_LISTEN};
 
     static INPUT_ONE: &str = "1080-60.y4m";
     static INPUT_TWO: &str = "1080-60-2.y4m";
-    static BITRATE: u32 = 6;
+    static QUALITY: FfmpegQuality = FfmpegQuality::ConstantBitrate(6);
     static FPS_LIMIT: u32 = 60;
     static ENCODER: &str = "h264_nvenc";
     static ENCODER_ARGS: &str =
@@ -248,7 +276,7 @@ mod tests {
         assert_eq!(args.fps_limit, 0);
         assert_eq!(args.send_progress, true);
         assert_eq!(args.report, false);
-        assert_eq!(args.bitrate, u32::default());
+        assert_eq!(args.quality, FfmpegQuality::default());
         assert_eq!(args.output_args, "-f null -");
         assert_eq!(args.is_vmaf, false);
         assert_eq!(args.stats_period, 0.5);
@@ -266,7 +294,7 @@ mod tests {
 
         assert_eq!(ffmpeg_args.first_input, INPUT_ONE);
         assert_eq!(ffmpeg_args.second_input, INPUT_TWO);
-        assert_eq!(ffmpeg_args.bitrate, BITRATE);
+        assert_eq!(ffmpeg_args.quality, QUALITY);
         assert_eq!(ffmpeg_args.encoder, ENCODER);
         assert_eq!(ffmpeg_args.encoder_args, ENCODER_ARGS);
     }
@@ -277,7 +305,7 @@ mod tests {
 
         assert_eq!(ffmpeg_args.first_input, INPUT_ONE);
         assert_eq!(ffmpeg_args.second_input, "");
-        assert_eq!(ffmpeg_args.bitrate, BITRATE);
+        assert_eq!(ffmpeg_args.quality, QUALITY);
         assert_eq!(ffmpeg_args.encoder, ENCODER);
         assert_eq!(ffmpeg_args.encoder_args, ENCODER_ARGS);
     }
@@ -321,7 +349,7 @@ mod tests {
     fn get_one_input_args() -> FfmpegArgs {
         let args = Cli {
             encoder: ENCODER.to_string(),
-            bitrate: BITRATE,
+            quality: QUALITY.clone(),
             check_quality: false,
             detect_overload: false,
             source_file: INPUT_ONE.to_string(),
@@ -336,7 +364,7 @@ mod tests {
             args.source_file,
             args.encoder,
             &ENCODER_ARGS.to_string(),
-            args.bitrate,
+            args.quality.clone(),
             false,
             false,
         );

--- a/ffmpeg/src/report_files.rs
+++ b/ffmpeg/src/report_files.rs
@@ -32,6 +32,25 @@ pub fn read_last_line_at(line_number: i32) -> String {
     return lines.next().unwrap().unwrap();
 }
 
+pub fn find_and_extract_vmaf_score() -> Result<c_float, &'static str> {
+    let log_file = File::open(get_latest_ffmpeg_report_file()).unwrap();
+    let reader = RevBufReader::new(log_file);
+    let lines = reader.lines();
+
+    // read from bottom until VMAF score is found
+    for candidate_line in lines {
+        let unwrapped_line = candidate_line.unwrap();
+        let vmaf_candidate = extract_vmaf_score(&unwrapped_line.as_str());
+        match vmaf_candidate {
+            Ok(vmaf_score) => return Ok(vmaf_score),
+            Err(_) => continue,
+        }
+    }
+
+    // if VMAF score could not be found, return error
+    Err("Could not find VMAF score")
+}
+
 pub fn capture_group(str: &str, regex: &str) -> String {
     let re = Regex::new(regex).unwrap();
     let caps = re.captures(str);

--- a/permutation/src/permutation.rs
+++ b/permutation/src/permutation.rs
@@ -1,12 +1,14 @@
 use ffmpeg::ffprobe::probe_for_video_metadata;
 use ffmpeg::metadata::MetaData;
+use ffmpeg::args::FfmpegQuality;
 
 #[derive(Clone)]
 pub struct Permutation {
     pub video_file: String,
     pub encoder: String,
     pub encoder_settings: String,
-    pub bitrate: u32,
+    //pub bitrate: u32,
+    pub quality: FfmpegQuality,
     pub metadata: MetaData,
     pub check_quality: bool,
     pub allow_duplicates: bool,
@@ -25,7 +27,8 @@ impl Permutation {
             video_file,
             encoder,
             encoder_settings: String::from(""),
-            bitrate: 0,
+            //bitrate: 0,
+            quality: FfmpegQuality::ConstantBitrate(0),
             metadata: MetaData::new(),
             check_quality: false,
             allow_duplicates: false,

--- a/permutor-cli/src/main.rs
+++ b/permutor-cli/src/main.rs
@@ -10,6 +10,7 @@ use codecs::permute::Permute;
 use codecs::qsv::QSV;
 use codecs::vendor::Vendor;
 use engine::permutation_engine::PermutationEngine;
+use ffmpeg::args::FfmpegQuality;
 use permutation::permutation::Permutation;
 
 use crate::permutor_cli::PermutorCli;
@@ -23,25 +24,28 @@ fn main() {
 
     log_special_arguments(&cli);
 
+    let cli_quality = cli.fetch_quality_args();
+    let quality_interval = cli.fetch_quality_interval();
+
     let mut engine = PermutationEngine::new(cli.log_output_directory.clone());
     let vendor = get_vendor_for_codec(&cli.encoder.clone());
-    for bitrate in get_bitrate_permutations(cli.bitrate, cli.max_bitrate_permutation.unwrap()) {
+    for quality in get_quality_permutations(cli_quality, cli.max_quality_permutation.unwrap(), quality_interval) {
         match vendor {
             Vendor::Nvidia => {
-                build_nvenc_setting_permutations(&mut engine, &cli, bitrate);
+                build_nvenc_setting_permutations(&mut engine, &cli, quality);
             }
             Vendor::AMD => {
-                build_amf_setting_permutations(&mut engine, &cli, bitrate);
+                panic!(); //build_amf_setting_permutations(&mut engine, &cli, bitrate);
             }
             Vendor::IntelQSV => {
                 if cli.encoder.contains("av1") {
-                    build_intel_av1_permutations(&mut engine, &cli, bitrate);
+                    panic!(); //build_intel_av1_permutations(&mut engine, &cli, bitrate);
                 } else {
-                    build_intel_igpu_permutations(&mut engine, &cli, bitrate);
+                    panic!(); //build_intel_igpu_permutations(&mut engine, &cli, bitrate);
                 }
             }
             Vendor::Apple => {
-                build_apple_silicon_h264_permutations(&mut engine, &cli, bitrate);
+                panic!(); //build_apple_silicon_h264_permutations(&mut engine, &cli, bitrate);
             }
             Vendor::Unknown => {}
         }
@@ -78,7 +82,7 @@ fn log_special_arguments(cli: &PermutorCli) {
 fn build_nvenc_setting_permutations(
     engine: &mut PermutationEngine,
     cli: &PermutorCli,
-    bitrate: u32,
+    quality: FfmpegQuality,
 ) {
     let mut nvenc = Nvenc::new(cli.encoder == "hevc_nvenc", cli.gpu, cli.no_b_frame);
 
@@ -89,7 +93,7 @@ fn build_nvenc_setting_permutations(
         let mut permutation = Permutation::new(cli.source_file.clone(), cli.encoder.clone());
         permutation.video_file = cli.source_file.clone();
         permutation.encoder_settings = settings;
-        permutation.bitrate = bitrate;
+        permutation.quality = quality;
         permutation.check_quality = cli.check_quality;
         permutation.verbose = cli.verbose;
         permutation.detect_overload = cli.detect_overload;
@@ -105,6 +109,7 @@ fn build_nvenc_setting_permutations(
     }
 }
 
+/*
 fn build_amf_setting_permutations(engine: &mut PermutationEngine, cli: &PermutorCli, bitrate: u32) {
     let mut amf = Amf::new(cli.encoder == "hevc_amf", cli.gpu);
 
@@ -212,13 +217,30 @@ fn build_apple_silicon_h264_permutations(
         }
     }
 }
+*/
 
-fn get_bitrate_permutations(starting_bitrate: u32, max_bitrate: u32) -> Vec<u32> {
-    let interval = 5;
-    let mut bitrates = Vec::new();
-    for i in 0..(((max_bitrate - starting_bitrate) / interval) + 1) {
-        bitrates.push(starting_bitrate + (interval * i));
+fn get_quality_permutations(starting_quality: FfmpegQuality, max_quality: u32, interval: i32) -> Vec<FfmpegQuality> {
+
+    let mut qualities = Vec::new();
+    let min: i32;
+    //let interval: i32;
+    match starting_quality {
+        FfmpegQuality::ConstantBitrate(b) => {
+            min = b as i32;
+            //interval = 5;
+        },
+        FfmpegQuality::ConstantQuality(q) => {
+            min  = q as i32;
+            //interval = -4;
+        }, // note interval is negative since quality increases with smaller CQs
     }
 
-    return bitrates;
+    for i in 0..(((max_quality as i32 - min) / interval) + 1) {
+        qualities.push(match starting_quality {
+            FfmpegQuality::ConstantBitrate(_) => FfmpegQuality::ConstantBitrate((min + (interval * i)) as u32),
+            FfmpegQuality::ConstantQuality(_) => FfmpegQuality::ConstantQuality((min + (interval * i)) as u32),
+        });
+    }
+
+    return qualities;
 }

--- a/permutor-cli/src/permutor_cli.rs
+++ b/permutor-cli/src/permutor_cli.rs
@@ -2,14 +2,19 @@ use clap::Parser;
 
 use cli::cli_util::{error_with_ack, standard_cli_check};
 
+use ffmpeg::args::FfmpegQuality;
+
 #[derive(Parser)]
 pub struct PermutorCli {
     /// the encoder you wish to benchmark: [h264_nvenc, hevc_nvenc, etc]
     #[arg(short, long, value_name = "encoder_name", default_value = "encoder")]
     pub encoder: String,
-    /// target bitrate (in Mb/s) to output; in combination with --bitrate-max-permutation, this is the starting permutation
-    #[arg(short, long, value_name = "bitrate", default_value = "10")]
-    pub bitrate: u32,
+    /// target bitrate (in Mb/s) to output; in combination with --max-bitrate-permutation, this is the starting permutation
+    #[arg(short, long, value_name = "bitrate")]
+    pub bitrate: Option<u32>,
+    /// target quality (in 0..51 range, smaller is better) to output; in combination with --max-quality-permutation, this is the starting permutation
+    #[arg(short, long, value_name = "quality")]
+    pub quality: Option<u32>,
     /// whether to run vmaf score on each permutation or not
     #[arg(short, long)]
     pub check_quality: bool,
@@ -34,9 +39,12 @@ pub struct PermutorCli {
     /// adds in '-pix_fmt yuv420p10le' to force 10-bit encoding
     #[arg(long)]
     pub ten_bit: bool,
-    /// maximum value to increase the bitrate to (in 5Mb/s intervals); if not specified, tool will not permute over bitrate values
-    #[arg(short, long, value_name = "bitrate")]
-    pub max_bitrate_permutation: Option<u32>,
+    /// maximum value to increase the bitrate or quality to. If not specified, tool will not permute over bitrate values
+    #[arg(short, long, value_name = "bitrate/quality")]
+    pub max_quality_permutation: Option<u32>,
+    /// bitrate or quality interval to increase the bitrate or quality by. (Default is 5Mb/s or 4 CQ intervals); only used if max_quality_permutation is specified
+    #[arg(short, long, value_name = "bitrate/quality interval")]
+    pub interval_quality_permutation: Option<u32>,
     /// logs useful information to help troubleshooting
     #[arg(short, long)]
     pub verbose: bool,
@@ -66,8 +74,32 @@ impl PermutorCli {
             error_with_ack(false);
         }
 
-        if self.max_bitrate_permutation.is_none() {
-            self.max_bitrate_permutation = Option::from(self.bitrate);
+        if self.bitrate.is_none() && self.quality.is_none() {
+            println!("Error: Neither constant bitrate or quality was provided, please specified one of the two");
+            error_with_ack(false);
+        }
+
+        if !self.bitrate.is_none() && !self.quality.is_none() {
+            println!("Error: Both constant bitrate and constant was provided, please specified one of the two");
+            error_with_ack(false);
+        }
+
+        if self.max_quality_permutation.is_none() {
+            self.max_quality_permutation = if !self.bitrate.is_none() {
+                Option::from(self.bitrate)
+            }
+            else {
+                Option::from(self.quality)
+            }
+        }
+        else {
+            if !self.bitrate.is_none() && self.fetch_quality_interval() == 0 {
+                println!("Error: Bitrate interval cannot be zero");
+                error_with_ack(false);
+            } else if !self.quality.is_none() && self.fetch_quality_interval() == 0 {
+                println!("Error: Quality interval cannot be zero");
+                error_with_ack(false);
+            }
         }
 
         if self.source_file.is_empty() && !self.files_directory.is_empty() {
@@ -82,5 +114,21 @@ impl PermutorCli {
             || self.verbose
             || self.test_run
             || self.allow_duplicate_scores;
+    }
+
+    pub fn fetch_quality_args(&self) -> FfmpegQuality {
+        if !self.bitrate.is_none() {
+            FfmpegQuality::ConstantBitrate(self.bitrate.unwrap())
+        }
+        else {
+            FfmpegQuality::ConstantQuality(self.quality.unwrap())
+        }
+    }
+
+    pub fn fetch_quality_interval(&self) -> i32 {
+        match self.fetch_quality_args() {
+            FfmpegQuality::ConstantBitrate(_) => self.interval_quality_permutation.unwrap_or(5) as i32,
+            FfmpegQuality::ConstantQuality(_) => -(self.interval_quality_permutation.unwrap_or(4) as i32), // quality increases as CQ decreases
+        }
     }
 }


### PR DESCRIPTION
This is my first time contributing to an open source project and also my first time using Rust so please forgive my code.

This change should allow permutor-cli to search for the output VMAF score instead of the hard coded line number.